### PR TITLE
feat: new dynamic values on gateserver & RSA changes

### DIFF
--- a/Libraries/Starlight.Crypto.Client/ClientCrypto.cs
+++ b/Libraries/Starlight.Crypto.Client/ClientCrypto.cs
@@ -14,7 +14,7 @@ namespace Starlight.Crypto.Client;
 public sealed class ClientCrypto : IDisposable
 {
     private const string ResourcePrefix = "Starlight.Crypto.Client.Resources";
-    private const string ContentKeyPrefix = ResourcePrefix + "Keys";
+    private const string ContentKeyPrefix = ResourcePrefix + ".Keys";
     private const string PemSuffix = "pem";
 
     private readonly DispatchRsaCrypto _dispatch;
@@ -46,15 +46,19 @@ public sealed class ClientCrypto : IDisposable
     {
         options ??= new ClientCryptoOptions();
         var assembly = typeof(ClientCrypto).Assembly;
+        var basePath = options.BasePath ?? Directory.GetCurrentDirectory();
+
+        var signingKeyPath = ResolvePath(options.SigningKeyPath, basePath);
+        var sdkKeyPath = ResolvePath(options.SdkKeyPath, basePath);
 
         var contentKeys = LoadContentKeys(assembly);
-        var signingKey = LoadOrCreateSigningKey(assembly, generateRsaKeys, options.SigningKeyPath);
+        var signingKey = LoadOrCreateSigningKey(assembly, generateRsaKeys, signingKeyPath, basePath);
 
         RsaCrypto sdk;
 
         try
         {
-            sdk = LoadOrCreateSdkKey(assembly, generateRsaKeys, options.SdkKeyPath);
+            sdk = LoadOrCreateSdkKey(assembly, generateRsaKeys, sdkKeyPath, basePath);
         }
         catch
         {
@@ -138,7 +142,7 @@ public sealed class ClientCrypto : IDisposable
                 continue;
             }
 
-            var idText = name[ContentKeyPrefix.Length..^PemSuffix.Length];
+            var idText = name[ContentKeyPrefix.Length..^PemSuffix.Length].Trim('.');
 
             if (int.TryParse(idText, out var keyId))
             {
@@ -149,10 +153,21 @@ public sealed class ClientCrypto : IDisposable
         return keys;
     }
 
-    private static RSA LoadOrCreateSigningKey(Assembly assembly, bool generateRsaKeys, string? path)
+    private static RSA LoadOrCreateSigningKey(Assembly assembly, bool generateRsaKeys, string? path, string basePath)
     {
-        if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+        if (path is not null)
         {
+            if (File.Exists(path))
+            {
+                return RsaKeyLoader.LoadPrivateKeyFile(path);
+            }
+
+            if (!generateRsaKeys)
+            {
+                throw new FileNotFoundException("The configured signing key does not exist.", path);
+            }
+
+            EnsureRsaKeyExists(path, keySize: 2048, RsaKeyExportFormat.Pkcs8Pem);
             return RsaKeyLoader.LoadPrivateKeyFile(path);
         }
 
@@ -164,17 +179,28 @@ public sealed class ClientCrypto : IDisposable
             return rsa;
         }
 
-        path ??= "keys/signing.pem";
+        path = Path.Combine(basePath, "keys", "signing.pem");
 
         EnsureRsaKeyExists(path, keySize: 2048, RsaKeyExportFormat.Pkcs8Pem);
 
         return RsaKeyLoader.LoadPrivateKeyFile(path);
     }
 
-    private static RsaCrypto LoadOrCreateSdkKey(Assembly assembly, bool generateRsaKeys, string? path)
+    private static RsaCrypto LoadOrCreateSdkKey(Assembly assembly, bool generateRsaKeys, string? path, string basePath)
     {
-        if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+        if (path is not null)
         {
+            if (File.Exists(path))
+            {
+                return RsaCrypto.FromBase64Pkcs8(File.ReadAllText(path));
+            }
+
+            if (!generateRsaKeys)
+            {
+                throw new FileNotFoundException("The configured SDK password key does not exist.", path);
+            }
+
+            EnsureRsaKeyExists(path, keySize: 2048, RsaKeyExportFormat.Pkcs8Base64);
             return RsaCrypto.FromBase64Pkcs8(File.ReadAllText(path));
         }
 
@@ -184,11 +210,21 @@ public sealed class ClientCrypto : IDisposable
             return RsaCrypto.FromBase64Pkcs8(key);
         }
 
-        path ??= "keys/sdk.pem";
+        path = Path.Combine(basePath, "keys", "sdk.pem");
 
         EnsureRsaKeyExists(path, keySize: 2048, RsaKeyExportFormat.Pkcs8Base64);
 
         return RsaCrypto.FromBase64Pkcs8(File.ReadAllText(path));
+    }
+
+    private static string? ResolvePath(string? path, string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        return Path.GetFullPath(path, basePath);
     }
 
     private static void EnsureRsaKeyExists(

--- a/Libraries/Starlight.Crypto.Client/ClientCryptoHostExtensions.cs
+++ b/Libraries/Starlight.Crypto.Client/ClientCryptoHostExtensions.cs
@@ -29,6 +29,7 @@ public static class ClientCryptoHostExtensions
         }
 
         state = new KeyState();
+        state.Options.BasePath = builder.Environment.ContentRootPath;
         builder.Properties[StateKey] = state;
         return state;
     }
@@ -59,7 +60,7 @@ public static class ClientCryptoHostExtensions
         {
             state.Options.SigningKeyPath = path;
             state.SigningKeyOwner = serviceName;
-        } else
+        } else if (!PathsEqual(state.Options.SigningKeyPath, path, state.Options.BasePath))
         {
             WarnConflict("signing", state.SigningKeyOwner, state.Options.SigningKeyPath, serviceName, path);
         }
@@ -85,7 +86,7 @@ public static class ClientCryptoHostExtensions
         {
             state.Options.SdkKeyPath = path;
             state.SdkKeyOwner = serviceName;
-        } else
+        } else if (!PathsEqual(state.Options.SdkKeyPath, path, state.Options.BasePath))
         {
             WarnConflict("SDK", state.SdkKeyOwner, state.Options.SdkKeyPath, serviceName, path);
         }
@@ -93,10 +94,20 @@ public static class ClientCryptoHostExtensions
         return builder;
     }
 
+    private static bool PathsEqual(string? left, string? right, string? basePath)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            return false;
+
+        basePath ??= Directory.GetCurrentDirectory();
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(Path.GetFullPath(left, basePath), Path.GetFullPath(right, basePath), comparison);
+    }
+
     private static void WarnConflict(string keyName, string? owner, string? ownerPath, string serviceName, string ignoredPath)
-        => Log.Debug(
+        => Log.Warning(
             "ClientCrypto {KeyName} key path already set to '{OwnerPath}' by {Owner}; ignoring '{IgnoredPath}' from {Service}. "
-            + "Per-service configs duplicate key paths and the first to register wins (SDK server takes precedence over the gate server). "
+            + "Per-service configs duplicate key paths and the first non-empty path to register wins. "
             + "If this is unexpected, align the key paths across service configs.",
             keyName, ownerPath, owner, ignoredPath, serviceName);
 }

--- a/Libraries/Starlight.Crypto.Client/ClientCryptoOptions.cs
+++ b/Libraries/Starlight.Crypto.Client/ClientCryptoOptions.cs
@@ -1,11 +1,17 @@
 namespace Starlight.Crypto.Client;
 
 /// <summary>
-/// Optional overrides for <see cref="ClientCrypto"/>. When a path is set and
-/// the file exists, it replaces the corresponding embedded key.
+/// Optional filesystem settings for <see cref="ClientCrypto"/>. Configured paths
+/// must exist when generation is disabled; when enabled, missing keys are generated.
 /// </summary>
 public sealed class ClientCryptoOptions
 {
+    /// <summary>
+    /// Base directory used to resolve relative key paths and the generated
+    /// <c>keys/signing.pem</c> and <c>keys/sdk.pem</c> defaults.
+    /// </summary>
+    public string? BasePath { get; set; }
+
     /// <summary>Filesystem path overriding the embedded signing ('cur') key.</summary>
     public string? SigningKeyPath { get; set; }
 

--- a/Libraries/Starlight.Rpc/Protobuf/starlight.account.proto
+++ b/Libraries/Starlight.Rpc/Protobuf/starlight.account.proto
@@ -6,15 +6,16 @@ option csharp_namespace = "Starlight.Rpc.Proto";
 
 import "starlight.proto";
 
-// Path: Game Server -> SDK
+// Path: Gate Server -> SDK
 // Subject: `sdk.account.validate`
 message ValidateAccountReq {
   string account_id = 1;
   string account_token = 2;
 }
 
-// Path: SDK -> Game Server
+// Path: SDK -> Gate Server
 // Subject: `sdk.account.validate`
 message ValidateAccountRsp {
   StarlightRetcode retcode = 1;
+  optional string country_code = 2;
 }

--- a/Source/Starlight.Gate/Session/Modules/LoginModule.cs
+++ b/Source/Starlight.Gate/Session/Modules/LoginModule.cs
@@ -23,11 +23,13 @@ public sealed class LoginModule(INetworkSession session)
     [Opcode]
     public async Task OnGetPlayerTokenReq(GetPlayerTokenReq msg)
     {
-        // TODO: Authenticate the user. Check if their account token matches.
-
-        // TODO: Check if the `gate_ticket` matches the expected value.
-        //       This call is also where we would kick the player if they are already
-        //       logged in elsewhere.
+        // Dispatch currently advertises an empty connect_gate_ticket. Reject anything else
+        // rather than silently accepting a ticket which Starlight did not issue.
+        if (!string.IsNullOrEmpty(msg.Ticket))
+        {
+            Reject(Retcode.RETCODE_GATE_TICKET_CHECK_ERROR, msg);
+            return;
+        }
 
         // Runs before the tunnel is opened so a bad key leaves nothing to unwind.
         if (!TrySignSeed(session.Server.ClientCrypto, msg, out var seed))
@@ -39,6 +41,26 @@ public sealed class LoginModule(INetworkSession session)
             return;
         }
 
+        var account = await ValidateAccount(msg);
+
+        if (account is null)
+        {
+            Reject(Retcode.RETCODE_ACCOUNT_VEIRFY_ERROR, msg);
+            return;
+        }
+
+        if (account.Retcode != StarlightRetcode.Success)
+        {
+            Reject(account.Retcode switch {
+                StarlightRetcode.AccountNotFound => Retcode.RETCODE_ACCOUNT_INFO_NOT_EXIST,
+                StarlightRetcode.AccountInvalidToken => Retcode.RETCODE_TOKEN_ERROR,
+                _ => Retcode.RETCODE_ACCOUNT_VEIRFY_ERROR
+            }, msg);
+            return;
+        }
+
+        // DbGate is the authority for the account -> player UID mapping and creates the
+        // player's row on first login.
         var uid = await ResolveUid(msg.AccountUid);
 
         if (uid is null)
@@ -50,7 +72,7 @@ public sealed class LoginModule(INetworkSession session)
             return;
         }
 
-        // TODO: Pick better server based on population and load.
+        // Tunnel routing owns game-server selection; the gate only supplies player metadata.
         var sessionInfo = new PlayerConnectNotify {
             Uid = uid.Value,
             AccountUid = msg.AccountUid,
@@ -82,12 +104,11 @@ public sealed class LoginModule(INetworkSession session)
             ServerRandKey = seed.ServerRandKey,
             Sign = seed.Signature,
             Uid = uid.Value,
-            // TODO: Replace with dynamic variables.
             AccountUid = msg.AccountUid,
-            Token = "somethingreallylong",
+            Token = msg.AccountToken,
             PlatformType = msg.PlatformType,
-            CountryCode = "US",
-            ClientIpStr = "127.0.0.1",
+            CountryCode = account.CountryCode,
+            ClientIpStr = session.Remote.Address.ToString(),
             ClientVersionRandomKey = VersionKey,
             KeyId = msg.KeyId
         });
@@ -96,6 +117,26 @@ public sealed class LoginModule(INetworkSession session)
         // this same value as (clientSeed ^ server_rand_key); server_rand_key
         // carries the combined seed so only the holder of clientSeed can extract it.
         session.Rekey(MtKey.Generate((ulong)seed.ServerSeed));
+    }
+
+    private async Task<ValidateAccountRsp?> ValidateAccount(GetPlayerTokenReq msg)
+    {
+        try
+        {
+            return await session.Server.Rpc.Request<ValidateAccountReq, ValidateAccountRsp>(
+                SdkSubjects.ValidateAccount,
+                new ValidateAccountReq {
+                    AccountId = msg.AccountUid,
+                    AccountToken = msg.AccountToken
+                },
+                ReplyTimeout,
+                session.Closing);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logger.Warning(ex, "Failed to validate account '{AccountUid}'", msg.AccountUid);
+            return null;
+        }
     }
 
     /// <summary>Looks up the uid backing <paramref name="accountUid"/>, or null if it can't be had.</summary>

--- a/Source/Starlight.SDK/AccountRpcService.cs
+++ b/Source/Starlight.SDK/AccountRpcService.cs
@@ -60,9 +60,7 @@ public sealed class AccountRpcService(
 
         if (retcode == StarlightRetcode.Success)
         {
-            response.CountryCode = string.IsNullOrWhiteSpace(account!.Country)
-                ? config.DefaultCountryCode
-                : account.Country;
+            response.CountryCode = string.IsNullOrWhiteSpace(account!.Country) ? config.DefaultCountryCode : account.Country;
         }
 
         await message.Reply(response);

--- a/Source/Starlight.SDK/AccountRpcService.cs
+++ b/Source/Starlight.SDK/AccountRpcService.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Starlight.Rpc;
+using Starlight.Rpc.Proto;
+using Starlight.SDK.Database;
+
+namespace Starlight.SDK;
+
+public sealed class AccountRpcService(
+    RpcTransport rpc,
+    IServiceScopeFactory scopeFactory,
+    SdkConfig config
+) : IHostedService
+{
+    private IDisposable? _subscription;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = await rpc.Subscribe<ValidateAccountReq>(
+            SdkSubjects.ValidateAccount,
+            ValidateAccount);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscription?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task ValidateAccount(ValidateAccountReq request, RpcMessage message)
+    {
+        if (!uint.TryParse(request.AccountId, out var accountId))
+        {
+            await message.Reply(new ValidateAccountRsp {
+                Retcode = StarlightRetcode.AccountNotFound
+            });
+            return;
+        }
+
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SdkDbContext>();
+
+        // Only retrieve the two values needed by the gate, and do not track an entity
+        // which this read-only request will never update.
+        var account = await db.Accounts
+            .AsNoTracking()
+            .Where(a => a.Id == accountId)
+            .Select(a => new { a.ComboToken, a.Country })
+            .FirstOrDefaultAsync();
+
+        var retcode = account switch {
+            null => StarlightRetcode.AccountNotFound,
+            _ when !string.Equals(account.ComboToken, request.AccountToken, StringComparison.Ordinal)
+                => StarlightRetcode.AccountInvalidToken,
+            _ => StarlightRetcode.Success
+        };
+
+        var response = new ValidateAccountRsp { Retcode = retcode };
+
+        if (retcode == StarlightRetcode.Success)
+        {
+            response.CountryCode = string.IsNullOrWhiteSpace(account!.Country)
+                ? config.DefaultCountryCode
+                : account.Country;
+        }
+
+        await message.Reply(response);
+    }
+}

--- a/Source/Starlight.SDK/AccountRpcService.cs
+++ b/Source/Starlight.SDK/AccountRpcService.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -51,7 +53,7 @@ public sealed class AccountRpcService(
 
         var retcode = account switch {
             null => StarlightRetcode.AccountNotFound,
-            _ when !string.Equals(account.ComboToken, request.AccountToken, StringComparison.Ordinal)
+            _ when !TokensMatch(account.ComboToken, request.AccountToken)
                 => StarlightRetcode.AccountInvalidToken,
             _ => StarlightRetcode.Success
         };
@@ -64,5 +66,14 @@ public sealed class AccountRpcService(
         }
 
         await message.Reply(response);
+    }
+
+    private static bool TokensMatch(string expected, string actual)
+    {
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var actualBytes = Encoding.UTF8.GetBytes(actual);
+
+        return expectedBytes.Length == actualBytes.Length &&
+               CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes);
     }
 }

--- a/Source/Starlight.SDK/DispatchConfig.cs
+++ b/Source/Starlight.SDK/DispatchConfig.cs
@@ -52,8 +52,9 @@ public sealed class DispatchConfig
     /// Filesystem path to the PKCS#8 RSA private key used for signing
     /// the region payload.
     /// <br/>
-    /// Leave empty to use the signing ('cur') key embedded in
-    /// <c>Starlight.Crypto.Client</c>.
+    /// Relative paths are resolved from the application content root. When empty,
+    /// <c>GenerateRsaKeys=true</c> uses <c>keys/signing.pem</c>; otherwise the
+    /// embedded signing ('cur') key is used.
     /// </summary>
     public string? RsaSigningKeyPath { get; set; } = "";
 

--- a/Source/Starlight.SDK/DispatchService.cs
+++ b/Source/Starlight.SDK/DispatchService.cs
@@ -52,7 +52,7 @@ public static partial class ServiceExtensions
     {
         var config = builder.Configuration.GetSection("Dispatch").Get<DispatchConfig>() ?? new DispatchConfig();
 
-        builder.TrySetSigningKeyPath("SDK server", config.RsaSigningKeyPath);
+        builder.TrySetSigningKeyPath("Dispatch server", config.RsaSigningKeyPath);
 
         builder.Services
             .AddSingleton(config)

--- a/Source/Starlight.SDK/SdkConfig.cs
+++ b/Source/Starlight.SDK/SdkConfig.cs
@@ -41,8 +41,9 @@ public sealed class SdkConfig
     /// <summary>
     /// Filesystem path to the PKCS#8 RSA private key the shield login
     /// endpoint uses to decrypt passwords sent with <c>is_crypto=true</c>.
-    /// Leave empty to use the SDK key embedded in
-    /// <c>Starlight.Crypto.Client</c>.
+    /// Relative paths are resolved from the application content root. When empty,
+    /// <c>GenerateRsaKeys=true</c> uses <c>keys/sdk.pem</c>; otherwise the embedded
+    /// SDK key is used.
     /// </summary>
     public string? PasswordRsaKeyPath { get; set; } = "";
 

--- a/Source/Starlight.SDK/SdkService.cs
+++ b/Source/Starlight.SDK/SdkService.cs
@@ -21,9 +21,18 @@ public static partial class ServiceExtensions
     {
         var config = builder.Configuration.GetSection("Sdk").Get<SdkConfig>() ?? new SdkConfig();
 
+        if (config.SkipRsaDecryption != config.MaPassport.Login.SkipRsaDecryption)
+        {
+            throw new InvalidOperationException(
+                "Sdk:SkipRsaDecryption and Sdk:MaPassport:Login:SkipRsaDecryption must match because "
+                + "the patch configuration exposes one shared useSdkRsa setting to the client.");
+        }
+
         builder.TrySetSdkKeyPath("SDK server", config.PasswordRsaKeyPath);
 
         builder.Services.AddStarlightDbContext<SdkDbContext>(config.Database);
+
+        builder.Services.AddHostedService<AccountRpcService>();
 
         if (!config.SkipSignatureCheck && string.IsNullOrEmpty(config.HmacKey))
         {

--- a/Source/Starlight/Commands/AccountCommand.cs
+++ b/Source/Starlight/Commands/AccountCommand.cs
@@ -51,9 +51,11 @@ public sealed class AccountCommand(
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(password) || password.Length < sdkConfig.MinPasswordLength)
+        if (string.IsNullOrWhiteSpace(password) || password.Length < sdkConfig.MinPasswordLength ||
+            password.Length > sdkConfig.MaPassport.Login.MaxPasswordLength)
         {
-            Log.Warning("Password must contain at least {MinLength} characters.", sdkConfig.MinPasswordLength);
+            Log.Warning("Password must contain at least {MinLength} and at most {MaxLength} characters.", sdkConfig.MinPasswordLength,
+                sdkConfig.MaPassport.Login.MaxPasswordLength);
             return;
         }
 

--- a/Source/Starlight/Commands/AccountCommand.cs
+++ b/Source/Starlight/Commands/AccountCommand.cs
@@ -1,0 +1,133 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Starlight.Crypto;
+using Starlight.Database;
+using Starlight.SDK;
+using Starlight.SDK.Database;
+using Starlight.SDK.Database.Models;
+
+namespace Starlight.Commands;
+
+public sealed class AccountCommand(
+    IServiceScopeFactory scopeFactory,
+    SdkConfig sdkConfig
+) : ICommand
+{
+    public string Name => "account";
+    public string Description => "Creates or deletes an SDK account.";
+    public string Usage => "account <create|delete> <args>";
+    public string[] Aliases => [];
+
+    public Task ExecuteAsync(string[] args, CancellationToken cancellationToken)
+    {
+        if (args.Length == 0)
+        {
+            LogUsage();
+            return Task.CompletedTask;
+        }
+
+        return args[0].ToLowerInvariant() switch {
+            "create" => CreateAsync(args[1..], cancellationToken),
+            "delete" => DeleteAsync(args[1..], cancellationToken),
+            _ => UnknownMode(args[0])
+        };
+    }
+
+    private async Task CreateAsync(string[] args, CancellationToken cancellationToken)
+    {
+        if (args.Length != 2)
+        {
+            Log.Warning("Usage: account create <username> <password>");
+            return;
+        }
+
+        var username = args[0];
+        var password = args[1];
+
+        if (string.IsNullOrWhiteSpace(username) || username.Length > Account.MaxUsernameLength)
+        {
+            Log.Warning("Username must contain 1-{MaxLength} characters.", Account.MaxUsernameLength);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(password) || password.Length < sdkConfig.MinPasswordLength)
+        {
+            Log.Warning("Password must contain at least {MinLength} characters.", sdkConfig.MinPasswordLength);
+            return;
+        }
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<SdkDbContext>();
+
+        if (await db.Accounts.AnyAsync(a => a.Username == username, cancellationToken))
+        {
+            Log.Warning("An account named '{Username}' already exists.", username);
+            return;
+        }
+
+        var account = new Account {
+            Username = username,
+            PasswordHash = Argon2Crypto.Hash(password),
+            PasswordTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+        };
+
+        db.Accounts.Add(account);
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (!cancellationToken.IsCancellationRequested &&
+                                                   DatabaseErrors.IsUniqueViolation(ex))
+        {
+            Log.Warning("An account named '{Username}' already exists.", username);
+            return;
+        }
+
+        Log.Information("Created account '{Username}' with id {AccountId}.", account.Username, account.Id);
+    }
+
+    private async Task DeleteAsync(string[] args, CancellationToken cancellationToken)
+    {
+        if (args.Length != 1)
+        {
+            Log.Warning("Usage: account delete <id>");
+            return;
+        }
+
+        if (!uint.TryParse(args[0], out var accountId))
+        {
+            Log.Warning("Account id must be an unsigned integer.");
+            return;
+        }
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<SdkDbContext>();
+        var account = await db.Accounts.FindAsync([accountId], cancellationToken);
+
+        if (account is null)
+        {
+            Log.Warning("Account id {AccountId} does not exist.", accountId);
+            return;
+        }
+
+        db.Accounts.Remove(account);
+        await db.SaveChangesAsync(cancellationToken);
+
+        Log.Information("Deleted account '{Username}' with id {AccountId}.", account.Username, account.Id);
+    }
+
+    private static Task UnknownMode(string mode)
+    {
+        Log.Warning("Unknown account mode '{Mode}'. Expected 'create' or 'delete'.", mode);
+        LogUsage();
+        return Task.CompletedTask;
+    }
+
+    private static void LogUsage()
+    {
+        Log.Information("Usage: account create <username> <password>");
+        Log.Information("       account delete <id>");
+    }
+}

--- a/Source/Starlight/Commands/AccountCommand.cs
+++ b/Source/Starlight/Commands/AccountCommand.cs
@@ -79,7 +79,7 @@ public sealed class AccountCommand(
             await db.SaveChangesAsync(cancellationToken);
         }
         catch (DbUpdateException ex) when (!cancellationToken.IsCancellationRequested &&
-                                                   DatabaseErrors.IsUniqueViolation(ex))
+                                           DatabaseErrors.IsUniqueViolation(ex))
         {
             Log.Warning("An account named '{Username}' already exists.", username);
             return;

--- a/Source/Starlight/Config.cs
+++ b/Source/Starlight/Config.cs
@@ -19,6 +19,11 @@ namespace Starlight;
 public sealed class Config
 {
     public LogEventLevel LogLevel { get; set; } = LogEventLevel.Information;
+    /// <summary>
+    /// Generates missing configured RSA keys, or the default files under <c>keys/</c>
+    /// when no paths are configured. When disabled, empty paths use embedded keys and
+    /// configured paths must already exist.
+    /// </summary>
     public bool GenerateRsaKeys { get; set; } = true;
     public GameConfig Game { get; set; } = new();
     public GateConfig Gate { get; set; } = new();

--- a/Tests/Starlight.Tests/ClientCryptoTests.cs
+++ b/Tests/Starlight.Tests/ClientCryptoTests.cs
@@ -1,0 +1,39 @@
+using Starlight.Crypto.Client;
+using Xunit;
+
+namespace Starlight.Tests;
+
+public sealed class ClientCryptoTests
+{
+    [Fact]
+    public void EmbeddedContentKeysAreDiscoveredById()
+    {
+        using var crypto = ClientCrypto.Create(generateRsaKeys: false);
+
+        Assert.Equal([2, 3, 4, 5], crypto.ContentKeys.Keys.Order());
+    }
+
+    [Fact]
+    public void MissingConfiguredSigningKeyFailsWhenGenerationIsDisabled()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"starlight-missing-{Guid.NewGuid():N}.pem");
+        var options = new ClientCryptoOptions { SigningKeyPath = path };
+
+        var error = Assert.Throws<FileNotFoundException>(() =>
+            ClientCrypto.Create(generateRsaKeys: false, options));
+
+        Assert.Equal(path, error.FileName);
+    }
+
+    [Fact]
+    public void MissingConfiguredSdkKeyFailsWhenGenerationIsDisabled()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"starlight-missing-{Guid.NewGuid():N}.pem");
+        var options = new ClientCryptoOptions { SdkKeyPath = path };
+
+        var error = Assert.Throws<FileNotFoundException>(() =>
+            ClientCrypto.Create(generateRsaKeys: false, options));
+
+        Assert.Equal(path, error.FileName);
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->

## Summary
Adds account management and validation across the SDK, gate and DbGate services. It also replaces hardcoded login response values and improves RSA key discovery, path handling, generation and configuration validation

## Type of Change
- [x] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Added the `account create <username> <password>` command
- Added the `account delete <id>` command
- Added an SDK RPC handler for validating account IDs and combo tokens
- Updated the Gate login flow to validate accounts through the SDK
- Uses DbGate as the authority for resolving and creating player UIDs
- Replaced hard-coded account tokens, country codes, and client IP addresses
- Added gate-ticket validation
- Fixed embedded RSA content key discovery
- Added configurable RSA key paths and content root relative path resolution
- Added missing-key generation and configuration validation
- Added checks for conflicting SDK RSA settings and key paths

## Implementation Details
- Account validation is performed by the SDK because it owns the account database. The Gate sends the account ID and combo token over RPC and receives the validation result and country code
- DbGate remains responsible for mapping account IDs to player UIDs and creating the player record on first login
- The account validation query uses `AsNoTracking()` and selects only the token and country fields needed by the Gate
- Relative RSA key paths are resolved against the application content root, and configured missing keys are generated when `GenerateRsaKeys` is enabled; otherwise startup fails clearly instead of silently fallinbg ack to an embedded key

## Testing
- [x] Unit tests added/updated
- [x] Existing tests pass
- [x] Manually tested

Could connect to the game with no issues.

## Performance Impact
- [ ] No impact
- [x] Minor impact
- [ ] Significant impact (explain below)

## Breaking Changes
- [ ] No
- [x] Yes (describe below)

Invalid RSA configurations now fail explicitly. Existing installations may need configuration changes under certain conditions.

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] CI passes
- [x] No unnecessary changes included
- [x] Documentation updated (if needed)

## Additional Notes
The content key prefix includes the separator intentionally:

```cs
ResourcePrefix + ".Keys"
```

<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->