### PR TITLE
feat(game): inventory system(ish) [weapons, avatars, mats], weapon equip

### DIFF
--- a/Game/Starlight.Game.Player/Avatar.cs
+++ b/Game/Starlight.Game.Player/Avatar.cs
@@ -47,14 +47,15 @@ public sealed class Avatar
         uint level = 1,
         uint constellation = 0,
         uint bornTime = 0,
-        ulong weaponGuid = 0)
+        ulong weaponGuid = 0
+    )
     {
         var config = data.AvatarData[avatarId];
         var depot = data.AvatarSkillDepotData[config.SkillDepotId];
         var weapon = data.WeaponData[config.InitialWeapon];
 
-        level = Math.Clamp(level, 1u, 90u);
-        constellation = Math.Clamp(constellation, 0u, 6u);
+        level = Math.Clamp(level, min: 1u, max: 90u);
+        constellation = Math.Clamp(constellation, min: 0u, max: 6u);
 
         return new Avatar {
             AvatarId = avatarId,

--- a/Game/Starlight.Game.Player/Avatar.cs
+++ b/Game/Starlight.Game.Player/Avatar.cs
@@ -22,11 +22,16 @@ public sealed class Avatar
 
     public uint SkillDepotId { get; private init; }
     public IReadOnlyList<uint> Skills { get; private init; } = [];
+    public IReadOnlyList<uint> Talents { get; private init; } = [];
     public IReadOnlyList<string> Abilities { get; private init; } = [];
 
-    public uint WeaponItemId { get; private init; }
-    public uint WeaponGadgetId { get; private init; }
-    public ulong WeaponGuid { get; private init; }
+    public uint Level { get; private init; } = 1;
+    public uint PromoteLevel { get; private init; }
+    public uint Constellation { get; private init; }
+
+    public uint WeaponItemId { get; private set; }
+    public uint WeaponGadgetId { get; private set; }
+    public ulong WeaponGuid { get; private set; }
 
     public IReadOnlyDictionary<uint, float> FightProps { get; private init; } = new Dictionary<uint, float>();
 
@@ -35,22 +40,36 @@ public sealed class Avatar
     /// The weapon takes the guid straight after <paramref name="guid"/>, which is the order the
     /// client expects the pair to arrive in.
     /// </summary>
-    public static Avatar Create(GameData data, uint avatarId, ulong guid)
+    public static Avatar Create(
+        GameData data,
+        uint avatarId,
+        ulong guid,
+        uint level = 1,
+        uint constellation = 0,
+        uint bornTime = 0,
+        ulong weaponGuid = 0)
     {
         var config = data.AvatarData[avatarId];
         var depot = data.AvatarSkillDepotData[config.SkillDepotId];
         var weapon = data.WeaponData[config.InitialWeapon];
 
+        level = Math.Clamp(level, 1u, 90u);
+        constellation = Math.Clamp(constellation, 0u, 6u);
+
         return new Avatar {
             AvatarId = avatarId,
             Guid = guid,
             SkillDepotId = config.SkillDepotId,
-            BornTime = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            BornTime = bornTime == 0 ? (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds() : bornTime,
             WeaponItemId = config.InitialWeapon,
             WeaponGadgetId = weapon.GadgetId,
-            WeaponGuid = guid + 1,
+            WeaponGuid = weaponGuid == 0 ? guid + 1 : weaponGuid,
+            Level = level,
+            PromoteLevel = WeaponItem.PromoteLevelFor(level),
+            Constellation = constellation,
             // Depots pad their skill list with zeroes for the slots a character doesn't have.
             Skills = [.. depot.Skills.Append(depot.EnergySkill).Where(skill => skill != 0)],
+            Talents = [.. depot.Talents.Where(talent => talent != 0).Take((int)constellation)],
             FightProps = new Dictionary<uint, float> {
                 [BaseHp] = config.HpBase,
                 [BaseAttack] = config.AttackBase,
@@ -66,6 +85,14 @@ public sealed class Avatar
         };
     }
 
+    /// <summary>Updates the weapon represented in this avatar's roster and scene data.</summary>
+    internal void EquipWeapon(WeaponItem weapon)
+    {
+        WeaponItemId = weapon.ItemId;
+        WeaponGadgetId = weapon.GadgetId;
+        WeaponGuid = weapon.Guid;
+    }
+
     /// <summary>This avatar as the client's roster sees it, rather than as a scene entity.</summary>
     public AvatarInfo Info()
     {
@@ -78,10 +105,17 @@ public sealed class Avatar
             BornTime = BornTime,
             WearingFlycloakId = DefaultFlycloak,
             EquipGuidList = [WeaponGuid],
+            CoreProudSkillLevel = Constellation,
+            FetterInfo = new AvatarFetterInfo { ExpLevel = 1 },
             PropMap = {
                 [(uint)PlayerProperty.Exp] = PlayerProperty.Exp.Value(0),
-                [(uint)PlayerProperty.Level] = PlayerProperty.Level.Value(1)
-            }
+                [(uint)PlayerProperty.Level] = PlayerProperty.Level.Value(Level),
+                [(uint)PlayerProperty.BreakLevel] = PlayerProperty.BreakLevel.Value(PromoteLevel),
+                [(uint)PlayerProperty.SatiationVal] = PlayerProperty.SatiationVal.Value(0),
+                [(uint)PlayerProperty.SatiationPenaltyTime] =
+                    PlayerProperty.SatiationPenaltyTime.Value(0)
+            },
+            TalentIdList = [.. Talents]
         };
 
         foreach (var (prop, value) in FightProps)

--- a/Game/Starlight.Game.Player/AvatarModule.cs
+++ b/Game/Starlight.Game.Player/AvatarModule.cs
@@ -1,3 +1,4 @@
+using Starlight.Common;
 using Starlight.Game.Modules;
 using Starlight.Game.Resources;
 using Starlight.Protocol;
@@ -5,7 +6,7 @@ using Starlight.Rpc.Proto;
 
 namespace Starlight.Game.Player;
 
-public sealed class AvatarModule(IPlayer player, GameData data) : IModule
+public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guidManager) : IModule
 {
     #region Beach Simulator
 
@@ -17,28 +18,57 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
     private Avatar[] _team = [];
     private readonly Dictionary<uint, Avatar> _avatars = [];
     private readonly Dictionary<uint, NetAvatar> _avatarState = [];
-    private ulong _nextAvatarGuid = 0x10000000;
     private bool _loaded;
 
     /// The avatars the player walks in with, in slot order.
-    public IReadOnlyList<Avatar> Team => _team;
+    public IReadOnlyList<Avatar> Team
+    {
+        get
+        {
+            lock (player.StateLock)
+            {
+                LoadState();
+                return [.. _team];
+            }
+        }
+    }
 
     /// Every avatar the player currently owns, keyed by avatar ID.
-    public IReadOnlyDictionary<uint, Avatar> Avatars => _avatars;
+    public IReadOnlyDictionary<uint, Avatar> Avatars
+    {
+        get
+        {
+            lock (player.StateLock)
+            {
+                LoadState();
+                return new Dictionary<uint, Avatar>(_avatars);
+            }
+        }
+    }
 
     [Lifecycle(LifecycleEvent.PlayerLogin)]
     public async Task<AvatarDataNotify> OnLogin()
     {
-        LoadState();
+        Avatar[] avatars;
+
+        lock (player.StateLock)
+        {
+            LoadState();
+            avatars = [.. _avatars.Values];
+        }
 
         var inventory = player.Module<InventoryModule>();
         inventory.LoadState();
 
-        foreach (var avatar in _avatars.Values)
+        foreach (var avatar in avatars)
         {
             if (inventory.TryGetWeapon(avatar.WeaponGuid, out var equipped))
             {
-                avatar.EquipWeapon(equipped);
+                lock (player.StateLock)
+                {
+                    avatar.EquipWeapon(equipped);
+                }
+
                 continue;
             }
 
@@ -46,110 +76,133 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
             var weapon = await inventory.AddWeapon(
                 data.WeaponData[avatar.WeaponItemId],
                 avatar.WeaponGuid);
-            avatar.EquipWeapon(weapon);
+
+            lock (player.StateLock)
+            {
+                avatar.EquipWeapon(weapon);
+            }
         }
 
-        return new AvatarDataNotify {
-            CurAvatarTeamId = TeamId,
-            ChooseAvatarGuid = _team[0].Guid,
-            OwnedFlycloakList = [Avatar.DefaultFlycloak],
-            AvatarList = [.. _avatars.Values.Select(avatar => avatar.Info())],
-            AvatarTeamMap = {
-                [TeamId] = new AvatarTeam {
-                    TeamName = $"Team {TeamId}",
-                    AvatarGuidList = [.._team.Select(avatar => avatar.Guid)]
+        lock (player.StateLock)
+        {
+            return new AvatarDataNotify {
+                CurAvatarTeamId = TeamId,
+                ChooseAvatarGuid = _team[0].Guid,
+                OwnedFlycloakList = [Avatar.DefaultFlycloak],
+                AvatarList = [.. _avatars.Values.Select(avatar => avatar.Info())],
+                AvatarTeamMap = {
+                    [TeamId] = new AvatarTeam {
+                        TeamName = $"Team {TeamId}",
+                        AvatarGuidList = [.._team.Select(avatar => avatar.Guid)]
+                    }
                 }
-            }
-        };
+            };
+        }
     }
 
     /// <summary>Equips a weapon, moving or swapping it when another avatar is using it.</summary>
     [Opcode]
     public async Task<WearEquipRsp> OnWearEquip(WearEquipReq msg)
     {
-        LoadState();
-
         var response = new WearEquipRsp {
             AvatarGuid = msg.AvatarGuid,
             EquipGuid = msg.EquipGuid
         };
+        var notifications = new List<AvatarEquipChangeNotify>();
 
-        var avatar = _avatars.Values.FirstOrDefault(candidate => candidate.Guid == msg.AvatarGuid);
-
-        if (avatar is null)
+        lock (player.StateLock)
         {
-            response.Retcode = (int)Retcode.RETCODE_ITEM_INVALID_TARGET;
-            return response;
+            LoadState();
+
+            var avatar = _avatars.Values.FirstOrDefault(candidate => candidate.Guid == msg.AvatarGuid);
+
+            if (avatar is null)
+            {
+                response.Retcode = (int)Retcode.RETCODE_ITEM_INVALID_TARGET;
+                return response;
+            }
+
+            var inventory = player.Module<InventoryModule>();
+            inventory.LoadState();
+
+            if (!inventory.TryGetWeapon(msg.EquipGuid, out var weapon))
+            {
+                response.Retcode = (int)Retcode.RETCODE_ITEM_NOT_EXIST;
+                return response;
+            }
+
+            if (avatar.WeaponGuid == weapon.Guid)
+                return response;
+
+            if (!inventory.TryGetWeapon(avatar.WeaponGuid, out var previousWeapon))
+            {
+                response.Retcode = (int)Retcode.RETCODE_ITEM_NOT_EXIST;
+                return response;
+            }
+
+            var otherAvatar = _avatars.Values.FirstOrDefault(candidate =>
+                candidate.Guid != avatar.Guid && candidate.WeaponGuid == weapon.Guid);
+
+            if (otherAvatar is not null)
+            {
+                // Clear the old owner's slot before assigning the replacement so the client never
+                // sees one GUID equipped by two avatars at once.
+                notifications.Add(new AvatarEquipChangeNotify {
+                    AvatarGuid = otherAvatar.Guid,
+                    EquipType = 6 // EQUIP_WEAPON
+                });
+
+                SetWeapon(otherAvatar, previousWeapon);
+                notifications.Add(CreateWeaponChangeNotify(otherAvatar, previousWeapon));
+            }
+
+            SetWeapon(avatar, weapon);
+            notifications.Add(CreateWeaponChangeNotify(avatar, weapon));
         }
 
-        var inventory = player.Module<InventoryModule>();
-        inventory.LoadState();
-
-        if (!inventory.TryGetWeapon(msg.EquipGuid, out var weapon))
+        foreach (var notification in notifications)
         {
-            response.Retcode = (int)Retcode.RETCODE_ITEM_NOT_EXIST;
-            return response;
+            await player.Send(notification);
         }
-
-        if (avatar.WeaponGuid == weapon.Guid)
-            return response;
-
-        if (!inventory.TryGetWeapon(avatar.WeaponGuid, out var previousWeapon))
-        {
-            response.Retcode = (int)Retcode.RETCODE_ITEM_NOT_EXIST;
-            return response;
-        }
-
-        var otherAvatar = _avatars.Values.FirstOrDefault(candidate =>
-            candidate.Guid != avatar.Guid && candidate.WeaponGuid == weapon.Guid);
-
-        if (otherAvatar is not null)
-        {
-            // Clear the old owner's slot before assigning the replacement so the client never
-            // sees one GUID equipped by two avatars at once.
-            await player.Send(new AvatarEquipChangeNotify {
-                AvatarGuid = otherAvatar.Guid,
-                EquipType = 6 // EQUIP_WEAPON
-            });
-
-            SetWeapon(otherAvatar, previousWeapon);
-            await NotifyWeaponChange(otherAvatar, previousWeapon);
-        }
-
-        SetWeapon(avatar, weapon);
-        await NotifyWeaponChange(avatar, weapon);
 
         return response;
     }
 
     /// <summary>Grants an avatar outside the active team and notifies the client.</summary>
-    public async Task<(Avatar Avatar, bool Added)> AddAvatar(
+    public async Task<(Avatar? Avatar, bool Added)> AddAvatar(
         uint avatarId,
         uint level = 1,
         uint constellation = 0
     )
     {
-        LoadState();
+        Avatar avatar;
 
-        if (_avatars.TryGetValue(avatarId, out var existing))
-            return (existing, false);
+        lock (player.StateLock)
+        {
+            if (!CanCreate(avatarId))
+                return (null, false);
 
-        var guid = (ulong)player.Uid << 32 | ++_nextAvatarGuid;
-        var avatar = Avatar.Create(data, avatarId, guid, level, constellation);
-        AdvanceGuid(avatar.Guid); // Reserve the following GUID for its starter weapon.
+            LoadState();
 
-        _avatars.Add(avatarId, avatar);
+            if (_avatars.TryGetValue(avatarId, out var existing))
+                return (existing, false);
 
-        var state = new NetAvatar {
-            AvatarId = avatar.AvatarId,
-            Guid = avatar.Guid,
-            Level = avatar.Level,
-            Constellation = avatar.Constellation,
-            BornTime = avatar.BornTime,
-            WeaponGuid = avatar.WeaponGuid
-        };
-        _avatarState.Add(avatarId, state);
-        player.State.Avatars.Add(state);
+            var guid = guidManager.GenGuid(GuidManager.GuidType.Avatar);
+            avatar = Avatar.Create(data, avatarId, guid, level, constellation);
+
+            _avatars.Add(avatarId, avatar);
+
+            var state = new NetAvatar {
+                AvatarId = avatar.AvatarId,
+                Guid = avatar.Guid,
+                Level = avatar.Level,
+                Constellation = avatar.Constellation,
+                BornTime = avatar.BornTime,
+                WeaponGuid = avatar.WeaponGuid
+            };
+            _avatarState.Add(avatarId, state);
+            player.State.Avatars.Add(state);
+        }
 
         var weapon = await player.Module<InventoryModule>()
             .AddWeapon(
@@ -167,8 +220,15 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
             Weapon = weapon.ToSceneProtocol()
         });
 
+        AvatarInfo avatarInfo;
+
+        lock (player.StateLock)
+        {
+            avatarInfo = avatar.Info();
+        }
+
         await player.Send(new AvatarAddNotify {
-            Avatar = avatar.Info(),
+            Avatar = avatarInfo,
             IsInTeam = false
         });
 
@@ -177,90 +237,88 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
 
     private void LoadState()
     {
-        if (_loaded)
-            return;
-
-        _loaded = true;
-
-        foreach (var state in player.State.Avatars)
+        lock (player.StateLock)
         {
-            if (state.AvatarId == 0 || state.Guid == 0 || _avatars.ContainsKey(state.AvatarId)
-                || !CanCreate(state.AvatarId))
-                continue;
+            if (_loaded)
+                return;
 
-            var avatar = Avatar.Create(
-                data,
-                state.AvatarId,
-                state.Guid,
-                state.Level,
-                state.Constellation,
-                state.BornTime,
-                state.WeaponGuid);
+            _loaded = true;
 
-            // State written before weapon persistence used the deterministic starter GUID.
-            if (state.WeaponGuid == 0)
-                state.WeaponGuid = avatar.WeaponGuid;
+            foreach (var state in player.State.Avatars)
+            {
+                if (state.AvatarId == 0 || state.Guid == 0 || _avatars.ContainsKey(state.AvatarId)
+                    || !CanCreate(state.AvatarId))
+                    continue;
 
-            _avatars.Add(avatar.AvatarId, avatar);
-            _avatarState.Add(avatar.AvatarId, state);
-            AdvanceGuid(avatar.Guid);
+                var avatar = Avatar.Create(
+                    data,
+                    state.AvatarId,
+                    state.Guid,
+                    state.Level,
+                    state.Constellation,
+                    state.BornTime,
+                    state.WeaponGuid);
+
+                // State written before weapon persistence used the deterministic starter GUID.
+                if (state.WeaponGuid == 0)
+                    state.WeaponGuid = avatar.WeaponGuid;
+
+                _avatars.Add(avatar.AvatarId, avatar);
+                _avatarState.Add(avatar.AvatarId, state);
+            }
+
+            // A brand-new player receives the starter roster once. It immediately becomes part of
+            // the persisted state, so reconnects preserve its GUID and born time.
+            foreach (var (slot, avatarId) in TeamAvatarIds.Index())
+            {
+                if (_avatars.ContainsKey(avatarId) || !CanCreate(avatarId))
+                    continue;
+
+                var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
+                var avatar = Avatar.Create(data, avatarId, guid);
+
+                var state = new NetAvatar {
+                    AvatarId = avatar.AvatarId,
+                    Guid = avatar.Guid,
+                    Level = avatar.Level,
+                    Constellation = avatar.Constellation,
+                    BornTime = avatar.BornTime,
+                    WeaponGuid = avatar.WeaponGuid
+                };
+
+                _avatars.Add(avatarId, avatar);
+                _avatarState.Add(avatarId, state);
+                player.State.Avatars.Add(state);
+            }
+
+            _team = TeamAvatarIds
+                .Where(_avatars.ContainsKey)
+                .Select(id => _avatars[id])
+                .ToArray();
         }
-
-        // A brand-new player receives the starter roster once. It immediately becomes part of
-        // the persisted state, so reconnects preserve its GUID and born time.
-        foreach (var (slot, avatarId) in TeamAvatarIds.Index())
-        {
-            if (_avatars.ContainsKey(avatarId) || !CanCreate(avatarId))
-                continue;
-
-            var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
-            var avatar = Avatar.Create(data, avatarId, guid);
-
-            var state = new NetAvatar {
-                AvatarId = avatar.AvatarId,
-                Guid = avatar.Guid,
-                Level = avatar.Level,
-                Constellation = avatar.Constellation,
-                BornTime = avatar.BornTime,
-                WeaponGuid = avatar.WeaponGuid
-            };
-
-            _avatars.Add(avatarId, avatar);
-            _avatarState.Add(avatarId, state);
-            player.State.Avatars.Add(state);
-            AdvanceGuid(avatar.Guid);
-        }
-
-        _team = TeamAvatarIds
-            .Where(_avatars.ContainsKey)
-            .Select(id => _avatars[id])
-            .ToArray();
     }
 
     private void SetWeapon(Avatar avatar, WeaponItem weapon)
     {
-        avatar.EquipWeapon(weapon);
-        _avatarState[avatar.AvatarId].WeaponGuid = weapon.Guid;
+        lock (player.StateLock)
+        {
+            avatar.EquipWeapon(weapon);
+            _avatarState[avatar.AvatarId].WeaponGuid = weapon.Guid;
+        }
     }
 
-    private Task NotifyWeaponChange(Avatar avatar, WeaponItem weapon)
-        => player.Send(new AvatarEquipChangeNotify {
+    private static AvatarEquipChangeNotify CreateWeaponChangeNotify(Avatar avatar, WeaponItem weapon)
+        => new() {
             AvatarGuid = avatar.Guid,
             EquipGuid = weapon.Guid,
             ItemId = weapon.ItemId,
             EquipType = 6, // EQUIP_WEAPON
             Weapon = weapon.ToSceneProtocol()
-        });
+        };
 
     private bool CanCreate(uint avatarId)
         => data.AvatarData.TryGetValue(avatarId, out var avatar)
            && data.AvatarSkillDepotData.ContainsKey(avatar.SkillDepotId)
            && data.WeaponData.ContainsKey(avatar.InitialWeapon)
            && data.Avatars.ContainsKey(avatarId);
-
-    private void AdvanceGuid(ulong guid)
-    {
-        if ((uint)(guid >> 32) == player.Uid)
-            _nextAvatarGuid = Math.Max(_nextAvatarGuid, (uint)guid + 1);
-    }
 }

--- a/Game/Starlight.Game.Player/AvatarModule.cs
+++ b/Game/Starlight.Game.Player/AvatarModule.cs
@@ -1,6 +1,7 @@
 using Starlight.Game.Modules;
 using Starlight.Game.Resources;
 using Starlight.Protocol;
+using Starlight.Rpc.Proto;
 
 namespace Starlight.Game.Player;
 
@@ -14,26 +15,45 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
     #endregion
 
     private Avatar[] _team = [];
+    private readonly Dictionary<uint, Avatar> _avatars = [];
+    private readonly Dictionary<uint, NetAvatar> _avatarState = [];
+    private ulong _nextAvatarGuid = 0x10000000;
+    private bool _loaded;
 
     /// The avatars the player walks in with, in slot order.
     public IReadOnlyList<Avatar> Team => _team;
 
-    [Lifecycle(LifecycleEvent.PlayerLogin)]
-    public AvatarDataNotify OnLogin()
-    {
-        // Guids only have to be unique to one player, and each avatar takes two of them: its own
-        // and its weapon's.
-        var guids = (ulong)player.Uid << 32;
+    /// Every avatar the player currently owns, keyed by avatar ID.
+    public IReadOnlyDictionary<uint, Avatar> Avatars => _avatars;
 
-        _team = TeamAvatarIds
-            .Select((id, slot) => Avatar.Create(data, id, guids + (ulong)(slot * 2 + 1)))
-            .ToArray();
+    [Lifecycle(LifecycleEvent.PlayerLogin)]
+    public async Task<AvatarDataNotify> OnLogin()
+    {
+        LoadState();
+
+        var inventory = player.Module<InventoryModule>();
+        inventory.LoadState();
+
+        foreach (var avatar in _avatars.Values)
+        {
+            if (inventory.TryGetWeapon(avatar.WeaponGuid, out var equipped))
+            {
+                avatar.EquipWeapon(equipped);
+                continue;
+            }
+
+            // Repair old or incomplete state with the avatar's initial weapon.
+            var weapon = await inventory.AddWeapon(
+                data.WeaponData[avatar.WeaponItemId],
+                avatar.WeaponGuid);
+            avatar.EquipWeapon(weapon);
+        }
 
         return new AvatarDataNotify {
             CurAvatarTeamId = TeamId,
             ChooseAvatarGuid = _team[0].Guid,
             OwnedFlycloakList = [Avatar.DefaultFlycloak],
-            AvatarList = [.. _team.Select(avatar => avatar.Info())],
+            AvatarList = [.. _avatars.Values.Select(avatar => avatar.Info())],
             AvatarTeamMap = {
                 [TeamId] = new AvatarTeam {
                     TeamName = $"Team {TeamId}",
@@ -41,5 +61,202 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
                 }
             }
         };
+    }
+
+    /// <summary>Equips a weapon, moving or swapping it when another avatar is using it.</summary>
+    [Opcode]
+    public async Task<WearEquipRsp> OnWearEquip(WearEquipReq msg)
+    {
+        LoadState();
+
+        var response = new WearEquipRsp {
+            AvatarGuid = msg.AvatarGuid,
+            EquipGuid = msg.EquipGuid
+        };
+
+        var avatar = _avatars.Values.FirstOrDefault(candidate => candidate.Guid == msg.AvatarGuid);
+        if (avatar is null)
+        {
+            response.Retcode = (int)Retcode.RETCODE_ITEM_INVALID_TARGET;
+            return response;
+        }
+
+        var inventory = player.Module<InventoryModule>();
+        inventory.LoadState();
+
+        if (!inventory.TryGetWeapon(msg.EquipGuid, out var weapon))
+        {
+            response.Retcode = (int)Retcode.RETCODE_ITEM_NOT_EXIST;
+            return response;
+        }
+
+        if (avatar.WeaponGuid == weapon.Guid)
+            return response;
+
+        if (!inventory.TryGetWeapon(avatar.WeaponGuid, out var previousWeapon))
+        {
+            response.Retcode = (int)Retcode.RETCODE_ITEM_NOT_EXIST;
+            return response;
+        }
+
+        var otherAvatar = _avatars.Values.FirstOrDefault(candidate =>
+            candidate.Guid != avatar.Guid && candidate.WeaponGuid == weapon.Guid);
+
+        if (otherAvatar is not null)
+        {
+            // Clear the old owner's slot before assigning the replacement so the client never
+            // sees one GUID equipped by two avatars at once.
+            await player.Send(new AvatarEquipChangeNotify {
+                AvatarGuid = otherAvatar.Guid,
+                EquipType = 6 // EQUIP_WEAPON
+            });
+
+            SetWeapon(otherAvatar, previousWeapon);
+            await NotifyWeaponChange(otherAvatar, previousWeapon);
+        }
+
+        SetWeapon(avatar, weapon);
+        await NotifyWeaponChange(avatar, weapon);
+
+        return response;
+    }
+
+    /// <summary>Grants an avatar outside the active team and notifies the client.</summary>
+    public async Task<(Avatar Avatar, bool Added)> AddAvatar(
+        uint avatarId,
+        uint level = 1,
+        uint constellation = 0)
+    {
+        LoadState();
+
+        if (_avatars.TryGetValue(avatarId, out var existing))
+            return (existing, false);
+
+        var guid = (ulong)player.Uid << 32 | ++_nextAvatarGuid;
+        var avatar = Avatar.Create(data, avatarId, guid, level, constellation);
+        AdvanceGuid(avatar.Guid); // Reserve the following GUID for its starter weapon.
+
+        _avatars.Add(avatarId, avatar);
+        var state = new NetAvatar {
+            AvatarId = avatar.AvatarId,
+            Guid = avatar.Guid,
+            Level = avatar.Level,
+            Constellation = avatar.Constellation,
+            BornTime = avatar.BornTime,
+            WeaponGuid = avatar.WeaponGuid
+        };
+        _avatarState.Add(avatarId, state);
+        player.State.Avatars.Add(state);
+
+        var weapon = await player.Module<InventoryModule>()
+            .AddWeapon(
+                data.WeaponData[avatar.WeaponItemId],
+                avatar.WeaponGuid,
+                showHint: false);
+
+        // Establish the starter-weapon equip before publishing the new avatar so both client
+        // stores receive the same weapon GUID.
+        await player.Send(new AvatarEquipChangeNotify {
+            AvatarGuid = avatar.Guid,
+            EquipGuid = weapon.Guid,
+            ItemId = weapon.ItemId,
+            EquipType = 6, // EQUIP_WEAPON
+            Weapon = weapon.ToSceneProtocol()
+        });
+
+        await player.Send(new AvatarAddNotify {
+            Avatar = avatar.Info(),
+            IsInTeam = false
+        });
+
+        return (avatar, true);
+    }
+
+    private void LoadState()
+    {
+        if (_loaded)
+            return;
+
+        _loaded = true;
+
+        foreach (var state in player.State.Avatars)
+        {
+            if (state.AvatarId == 0 || state.Guid == 0 || _avatars.ContainsKey(state.AvatarId)
+                || !CanCreate(state.AvatarId))
+                continue;
+
+            var avatar = Avatar.Create(
+                data,
+                state.AvatarId,
+                state.Guid,
+                state.Level,
+                state.Constellation,
+                state.BornTime,
+                state.WeaponGuid);
+
+            // State written before weapon persistence used the deterministic starter GUID.
+            if (state.WeaponGuid == 0)
+                state.WeaponGuid = avatar.WeaponGuid;
+
+            _avatars.Add(avatar.AvatarId, avatar);
+            _avatarState.Add(avatar.AvatarId, state);
+            AdvanceGuid(avatar.Guid);
+        }
+
+        // A brand-new player receives the starter roster once. It immediately becomes part of
+        // the persisted state, so reconnects preserve its GUID and born time.
+        foreach (var (slot, avatarId) in TeamAvatarIds.Index())
+        {
+            if (_avatars.ContainsKey(avatarId) || !CanCreate(avatarId))
+                continue;
+
+            var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
+            var avatar = Avatar.Create(data, avatarId, guid);
+            var state = new NetAvatar {
+                AvatarId = avatar.AvatarId,
+                Guid = avatar.Guid,
+                Level = avatar.Level,
+                Constellation = avatar.Constellation,
+                BornTime = avatar.BornTime,
+                WeaponGuid = avatar.WeaponGuid
+            };
+
+            _avatars.Add(avatarId, avatar);
+            _avatarState.Add(avatarId, state);
+            player.State.Avatars.Add(state);
+            AdvanceGuid(avatar.Guid);
+        }
+
+        _team = TeamAvatarIds
+            .Where(_avatars.ContainsKey)
+            .Select(id => _avatars[id])
+            .ToArray();
+    }
+
+    private void SetWeapon(Avatar avatar, WeaponItem weapon)
+    {
+        avatar.EquipWeapon(weapon);
+        _avatarState[avatar.AvatarId].WeaponGuid = weapon.Guid;
+    }
+
+    private Task NotifyWeaponChange(Avatar avatar, WeaponItem weapon)
+        => player.Send(new AvatarEquipChangeNotify {
+            AvatarGuid = avatar.Guid,
+            EquipGuid = weapon.Guid,
+            ItemId = weapon.ItemId,
+            EquipType = 6, // EQUIP_WEAPON
+            Weapon = weapon.ToSceneProtocol()
+        });
+
+    private bool CanCreate(uint avatarId)
+        => data.AvatarData.TryGetValue(avatarId, out var avatar)
+           && data.AvatarSkillDepotData.ContainsKey(avatar.SkillDepotId)
+           && data.WeaponData.ContainsKey(avatar.InitialWeapon)
+           && data.Avatars.ContainsKey(avatarId);
+
+    private void AdvanceGuid(ulong guid)
+    {
+        if ((uint)(guid >> 32) == player.Uid)
+            _nextAvatarGuid = Math.Max(_nextAvatarGuid, (uint)guid + 1);
     }
 }

--- a/Game/Starlight.Game.Player/AvatarModule.cs
+++ b/Game/Starlight.Game.Player/AvatarModule.cs
@@ -75,6 +75,7 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
         };
 
         var avatar = _avatars.Values.FirstOrDefault(candidate => candidate.Guid == msg.AvatarGuid);
+
         if (avatar is null)
         {
             response.Retcode = (int)Retcode.RETCODE_ITEM_INVALID_TARGET;
@@ -125,7 +126,8 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
     public async Task<(Avatar Avatar, bool Added)> AddAvatar(
         uint avatarId,
         uint level = 1,
-        uint constellation = 0)
+        uint constellation = 0
+    )
     {
         LoadState();
 
@@ -137,6 +139,7 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
         AdvanceGuid(avatar.Guid); // Reserve the following GUID for its starter weapon.
 
         _avatars.Add(avatarId, avatar);
+
         var state = new NetAvatar {
             AvatarId = avatar.AvatarId,
             Guid = avatar.Guid,
@@ -212,6 +215,7 @@ public sealed class AvatarModule(IPlayer player, GameData data) : IModule
 
             var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
             var avatar = Avatar.Create(data, avatarId, guid);
+
             var state = new NetAvatar {
                 AvatarId = avatar.AvatarId,
                 Guid = avatar.Guid,

--- a/Game/Starlight.Game.Player/InventoryItem.cs
+++ b/Game/Starlight.Game.Player/InventoryItem.cs
@@ -14,12 +14,9 @@ public sealed class MaterialItem : InventoryItem
 {
     public uint Count { get; internal set; }
 
-    public override Item ToProtocol()
-    {
-        return new Item {
-            ItemId = ItemId,
-            Guid = Guid,
-            Material = new Material { Count = Count }
-        };
-    }
+    public override Item ToProtocol() => new() {
+        ItemId = ItemId,
+        Guid = Guid,
+        Material = new Material { Count = Count }
+    };
 }

--- a/Game/Starlight.Game.Player/InventoryItem.cs
+++ b/Game/Starlight.Game.Player/InventoryItem.cs
@@ -1,0 +1,25 @@
+using Starlight.Protocol;
+
+namespace Starlight.Game.Player;
+
+public abstract class InventoryItem
+{
+    public required uint ItemId { get; init; }
+    public required ulong Guid { get; init; }
+
+    public abstract Item ToProtocol();
+}
+
+public sealed class MaterialItem : InventoryItem
+{
+    public uint Count { get; internal set; }
+
+    public override Item ToProtocol()
+    {
+        return new Item {
+            ItemId = ItemId,
+            Guid = Guid,
+            Material = new Material { Count = Count }
+        };
+    }
+}

--- a/Game/Starlight.Game.Player/InventoryModule.cs
+++ b/Game/Starlight.Game.Player/InventoryModule.cs
@@ -1,13 +1,16 @@
 using System.Diagnostics.CodeAnalysis;
+using Starlight.Common;
 using Starlight.Game.Modules;
+using Starlight.Game.Resources;
 using Starlight.Game.Resources.Excel;
 using Starlight.Protocol;
 using Starlight.Rpc.Proto;
+using IMessage = Starlight.Protobuf.Core.IMessage;
 
 namespace Starlight.Game.Player;
 
 /// <summary>Owns one player's material stacks and equipment instances.</summary>
-public sealed class InventoryModule(IPlayer player) : IModule
+public sealed class InventoryModule(IPlayer player, GuidManager guidManager, GameData data) : IModule
 {
     private const uint PackWeightLimit = 30000;
     private const int MaterialCountLimit = 2000;
@@ -19,38 +22,69 @@ public sealed class InventoryModule(IPlayer player) : IModule
     private readonly Dictionary<ulong, WeaponItem> _weapons = [];
     private readonly Dictionary<uint, NetMaterial> _materialState = [];
     private readonly Dictionary<ulong, NetWeapon> _weaponState = [];
-
-    // The low range is currently occupied by starter avatars and their weapons. This partition
-    // keeps temporary inventory GUIDs separate until the allocator is persisted in DbGate.
-    private ulong _nextGuid = 0x20000000;
     private bool _loaded;
     private bool _loggedIn;
 
-    public IReadOnlyCollection<MaterialItem> Materials => _materials.Values;
-    public IReadOnlyCollection<WeaponItem> Weapons => _weapons.Values;
+    public IReadOnlyCollection<MaterialItem> Materials
+    {
+        get
+        {
+            lock (player.StateLock)
+            {
+                LoadState();
+                return [.. _materials.Values];
+            }
+        }
+    }
+
+    public IReadOnlyCollection<WeaponItem> Weapons
+    {
+        get
+        {
+            lock (player.StateLock)
+            {
+                LoadState();
+                return [.. _weapons.Values];
+            }
+        }
+    }
 
     public bool TryGetMaterial(uint itemId, [NotNullWhen(true)] out MaterialItem? item)
     {
-        LoadState();
-        return _materials.TryGetValue(itemId, out item);
+        lock (player.StateLock)
+        {
+            LoadState();
+            return _materials.TryGetValue(itemId, out item);
+        }
     }
 
     public bool TryGetWeapon(ulong guid, [NotNullWhen(true)] out WeaponItem? item)
     {
-        LoadState();
-        return _weapons.TryGetValue(guid, out item);
+        lock (player.StateLock)
+        {
+            LoadState();
+            return _weapons.TryGetValue(guid, out item);
+        }
     }
 
     public async Task<MaterialItem> AddMaterial(uint itemId, uint count)
     {
-        LoadState();
         ArgumentOutOfRangeException.ThrowIfZero(count);
+        AddedItem change;
 
-        if (!_materials.ContainsKey(itemId) && _materials.Count >= MaterialCountLimit)
-            throw new InvalidOperationException("The material inventory is full.");
+        lock (player.StateLock)
+        {
+            LoadState();
 
-        var change = AddMaterialCore(itemId, count);
-        await NotifyAdded([change]);
+            if (!_materials.ContainsKey(itemId) && _materials.Count >= MaterialCountLimit)
+                throw new InvalidOperationException("The material inventory is full.");
+
+            change = AddMaterialCore(itemId, count);
+        }
+
+        if (change.Count > 0)
+            await NotifyAdded([change]);
+
         return (MaterialItem)change.Item;
     }
 
@@ -60,18 +94,25 @@ public sealed class InventoryModule(IPlayer player) : IModule
         bool showHint = true
     )
     {
-        LoadState();
         ArgumentOutOfRangeException.ThrowIfZero(count);
 
         var changes = new List<AddedItem>();
 
-        foreach (var itemId in itemIds.Distinct())
+        lock (player.StateLock)
         {
-            // Existing stacks can still be updated when every material slot is occupied.
-            if (!_materials.ContainsKey(itemId) && _materials.Count >= MaterialCountLimit)
-                continue;
+            LoadState();
 
-            changes.Add(AddMaterialCore(itemId, count));
+            foreach (var itemId in itemIds.Distinct())
+            {
+                // Existing stacks can still be updated when every material slot is occupied.
+                if (!_materials.ContainsKey(itemId) && _materials.Count >= MaterialCountLimit)
+                    continue;
+
+                var change = AddMaterialCore(itemId, count);
+
+                if (change.Count > 0)
+                    changes.Add(change);
+            }
         }
 
         await NotifyAdded(changes, showHint);
@@ -86,25 +127,29 @@ public sealed class InventoryModule(IPlayer player) : IModule
         bool showHint = true
     )
     {
-        LoadState();
         ArgumentOutOfRangeException.ThrowIfZero(amount);
         level = Math.Clamp(level, min: 1u, max: 90u);
         refinement = Math.Clamp(refinement, min: 1u, max: 5u);
 
         var changes = new List<AddedItem>();
 
-        foreach (var data in weapons)
+        lock (player.StateLock)
         {
-            for (var copy = 0u; copy < amount; copy++)
+            LoadState();
+
+            foreach (var weaponData in weapons)
             {
+                for (var copy = 0u; copy < amount; copy++)
+                {
+                    if (_weapons.Count >= WeaponCountLimit)
+                        break;
+
+                    changes.Add(AddWeaponCore(weaponData, NextGuid(), level, refinement));
+                }
+
                 if (_weapons.Count >= WeaponCountLimit)
                     break;
-
-                changes.Add(AddWeaponCore(data, NextGuid(), level, refinement));
             }
-
-            if (_weapons.Count >= WeaponCountLimit)
-                break;
         }
 
         await NotifyAdded(changes, showHint);
@@ -120,67 +165,92 @@ public sealed class InventoryModule(IPlayer player) : IModule
         bool showHint = true
     )
     {
-        LoadState();
+        AddedItem? change = null;
+        WeaponItem item;
 
-        if (_weapons.TryGetValue(guid, out var existing))
-            return existing;
+        lock (player.StateLock)
+        {
+            LoadState();
 
-        if (_weapons.Count >= WeaponCountLimit)
-            throw new InvalidOperationException("The weapon inventory is full.");
+            if (_weapons.TryGetValue(guid, out var existing))
+                return existing;
 
-        var change = AddWeaponCore(
-            data,
-            guid,
-            Math.Clamp(level, min: 1u, max: 90u),
-            Math.Clamp(refinement, min: 1u, max: 5u));
+            if (_weapons.Count >= WeaponCountLimit)
+                throw new InvalidOperationException("The weapon inventory is full.");
 
-        await NotifyAdded([change], showHint);
-        return (WeaponItem)change.Item;
+            change = AddWeaponCore(
+                data,
+                guid,
+                Math.Clamp(level, min: 1u, max: 90u),
+                Math.Clamp(refinement, min: 1u, max: 5u));
+            item = (WeaponItem)change.Value.Item;
+        }
+
+        await NotifyAdded([change.Value], showHint);
+        return item;
     }
 
     public async Task<bool> RemoveMaterial(uint itemId, uint count)
     {
-        LoadState();
+        IMessage? notification = null;
 
-        if (!_materials.TryGetValue(itemId, out var item) || count == 0 || item.Count < count)
-            return false;
-
-        item.Count -= count;
-
-        if (item.Count == 0)
+        lock (player.StateLock)
         {
-            _materials.Remove(itemId);
+            LoadState();
 
-            if (_materialState.Remove(itemId, out var state))
-                player.State.Materials.Remove(state);
+            if (!_materials.TryGetValue(itemId, out var item) || count == 0 || item.Count < count)
+                return false;
 
-            if (_loggedIn)
+            item.Count -= count;
+
+            if (item.Count == 0)
             {
-                await player.Send(new StoreItemDelNotify {
-                    StoreType = StoreType.STORE_TYPE_PACK,
-                    GuidList = { item.Guid }
-                });
-            }
-        } else
-        {
-            _materialState[itemId].Count = item.Count;
+                _materials.Remove(itemId);
 
-            if (_loggedIn)
+                if (_materialState.Remove(itemId, out var state))
+                    player.State.Materials.Remove(state);
+
+                if (_loggedIn)
+                {
+                    notification = new StoreItemDelNotify {
+                        StoreType = StoreType.STORE_TYPE_PACK,
+                        GuidList = { item.Guid }
+                    };
+                }
+            } else
             {
-                await player.Send(new StoreItemChangeNotify {
-                    StoreType = StoreType.STORE_TYPE_PACK,
-                    ItemList = { item.ToProtocol() }
-                });
+                _materialState[itemId].Count = item.Count;
+
+                if (_loggedIn)
+                {
+                    notification = new StoreItemChangeNotify {
+                        StoreType = StoreType.STORE_TYPE_PACK,
+                        ItemList = { item.ToProtocol() }
+                    };
+                }
             }
         }
+
+        if (notification is not null)
+            await player.Send(notification);
 
         return true;
     }
 
-    [Lifecycle(LifecycleEvent.PlayerLogin)]
+    [Lifecycle(LifecycleEvent.PlayerLogin, LifecycleOrder.HighPriority)]
     public async Task OnLogin()
     {
-        LoadState();
+        List<Item> items;
+
+        lock (player.StateLock)
+        {
+            LoadState();
+
+            items = [
+                .. _materials.Values.Select(item => item.ToProtocol()),
+                .. _weapons.Values.Select(item => item.ToProtocol())
+            ];
+        }
 
         await player.Send(new StoreWeightLimitNotify {
             StoreType = StoreType.STORE_TYPE_PACK,
@@ -190,38 +260,59 @@ public sealed class InventoryModule(IPlayer player) : IModule
             WeightLimit = PackWeightLimit
         });
 
-        var items = _materials.Values.Select(item => item.ToProtocol())
-            .Concat(_weapons.Values.Select(item => item.ToProtocol()));
-
         await player.Send(new PlayerStoreNotify {
             StoreType = StoreType.STORE_TYPE_PACK,
             WeightLimit = PackWeightLimit,
-            ItemList = [.. items]
+            ItemList = items
         });
 
-        _loggedIn = true;
+        lock (player.StateLock)
+        {
+            _loggedIn = true;
+        }
     }
 
-    private AddedItem AddMaterialCore(uint itemId, uint count)
+    private AddedItem AddMaterialCore(uint itemId, uint requestedCount)
     {
+        if (!data.MaterialData.TryGetValue(itemId, out var materialData))
+            throw new ArgumentException($"Material {itemId} does not exist.", nameof(itemId));
+
+        var stackLimit = Math.Max(materialData.StackLimit, val2: 1u);
+
         if (!_materials.TryGetValue(itemId, out var item))
         {
+            var addedCount = Math.Min(requestedCount, stackLimit);
+
             item = new MaterialItem {
                 ItemId = itemId,
                 Guid = NextGuid(),
-                Count = count
+                Count = addedCount
             };
 
             _materials.Add(itemId, item);
-            var state = new NetMaterial { ItemId = item.ItemId, Guid = item.Guid, Count = item.Count };
+
+            var state = new NetMaterial {
+                ItemId = item.ItemId,
+                Guid = item.Guid,
+                Count = item.Count
+            };
+
             _materialState.Add(itemId, state);
             player.State.Materials.Add(state);
-            return new AddedItem(item, count, IsNew: true);
+
+            return new AddedItem(item, item.ToProtocol(), addedCount, IsNew: true);
         }
 
-        item.Count = checked(item.Count + count);
+        if (item.Count >= stackLimit)
+            return new AddedItem(item, item.ToProtocol(), Count: 0, IsNew: false);
+
+        var availableSpace = stackLimit - item.Count;
+        var added = Math.Min(requestedCount, availableSpace);
+
+        item.Count += added;
         _materialState[itemId].Count = item.Count;
-        return new AddedItem(item, count, IsNew: false);
+
+        return new AddedItem(item, item.ToProtocol(), added, IsNew: false);
     }
 
     private AddedItem AddWeaponCore(WeaponData data, ulong guid, uint level, uint refinement)
@@ -249,61 +340,65 @@ public sealed class InventoryModule(IPlayer player) : IModule
         };
         _weaponState.Add(guid, state);
         player.State.Weapons.Add(state);
-        return new AddedItem(item, Count: 1, IsNew: true);
+        return new AddedItem(item, item.ToProtocol(), Count: 1, IsNew: true);
     }
 
     /// <summary>Hydrates the module once from the state DbGate attached to the player.</summary>
     internal void LoadState()
     {
-        if (_loaded)
-            return;
-
-        _loaded = true;
-
-        foreach (var state in player.State.Materials.Take(MaterialCountLimit))
+        lock (player.StateLock)
         {
-            if (state.ItemId == 0 || state.Guid == 0 || state.Count == 0
-                || _materials.ContainsKey(state.ItemId))
-                continue;
+            if (_loaded)
+                return;
 
-            _materials.Add(state.ItemId, new MaterialItem {
-                ItemId = state.ItemId,
-                Guid = state.Guid,
-                Count = state.Count
-            });
-            _materialState.Add(state.ItemId, state);
-            AdvanceGuid(state.Guid);
+            _loaded = true;
+
+            foreach (var state in player.State.Materials.Take(MaterialCountLimit))
+            {
+                if (state.ItemId == 0 || state.Guid == 0 || state.Count == 0
+                    || _materials.ContainsKey(state.ItemId))
+                    continue;
+
+                if (!data.MaterialData.TryGetValue(state.ItemId, out var materialData))
+                    continue;
+
+                var stackLimit = Math.Max(materialData.StackLimit, val2: 1u);
+                state.Count = Math.Min(state.Count, stackLimit);
+
+                _materials.Add(state.ItemId, new MaterialItem {
+                    ItemId = state.ItemId,
+                    Guid = state.Guid,
+                    Count = state.Count
+                });
+                _materialState.Add(state.ItemId, state);
+            }
+
+            foreach (var state in player.State.Weapons.Take(WeaponCountLimit))
+            {
+                if (state.ItemId == 0 || state.Guid == 0 || _weapons.ContainsKey(state.Guid))
+                    continue;
+
+                _weapons.Add(state.Guid, new WeaponItem {
+                    ItemId = state.ItemId,
+                    Guid = state.Guid,
+                    GadgetId = state.GadgetId,
+                    Level = Math.Clamp(state.Level, min: 1u, max: 90u),
+                    Refinement = Math.Clamp(state.Refinement, min: 1u, max: 5u),
+                    PromoteLevel = state.PromoteLevel,
+                    AffixId = state.AffixId
+                });
+                _weaponState.Add(state.Guid, state);
+            }
         }
-
-        foreach (var state in player.State.Weapons.Take(WeaponCountLimit))
-        {
-            if (state.ItemId == 0 || state.Guid == 0 || _weapons.ContainsKey(state.Guid))
-                continue;
-
-            _weapons.Add(state.Guid, new WeaponItem {
-                ItemId = state.ItemId,
-                Guid = state.Guid,
-                GadgetId = state.GadgetId,
-                Level = Math.Clamp(state.Level, min: 1u, max: 90u),
-                Refinement = Math.Clamp(state.Refinement, min: 1u, max: 5u),
-                PromoteLevel = state.PromoteLevel,
-                AffixId = state.AffixId
-            });
-            _weaponState.Add(state.Guid, state);
-            AdvanceGuid(state.Guid);
-        }
-    }
-
-    private void AdvanceGuid(ulong guid)
-    {
-        if ((uint)(guid >> 32) == player.Uid)
-            _nextGuid = Math.Max(_nextGuid, (uint)guid);
     }
 
     private async Task NotifyAdded(IEnumerable<AddedItem> added, bool showHint = true)
     {
-        if (!_loggedIn)
-            return;
+        lock (player.StateLock)
+        {
+            if (!_loggedIn)
+                return;
+        }
 
         var chunks = added.Chunk(NotifyChunkSize).ToArray();
 
@@ -311,7 +406,7 @@ public sealed class InventoryModule(IPlayer player) : IModule
         {
             await player.Send(new StoreItemChangeNotify {
                 StoreType = StoreType.STORE_TYPE_PACK,
-                ItemList = [.. chunk.Select(change => change.Item.ToProtocol())]
+                ItemList = [.. chunk.Select(change => change.Protocol)]
             });
 
             if (showHint)
@@ -335,7 +430,12 @@ public sealed class InventoryModule(IPlayer player) : IModule
         }
     }
 
-    private ulong NextGuid() => (ulong)player.Uid << 32 | ++_nextGuid;
+    private ulong NextGuid() => guidManager.GenGuid(GuidManager.GuidType.Item);
 
-    private readonly record struct AddedItem(InventoryItem Item, uint Count, bool IsNew);
+    private readonly record struct AddedItem(
+        InventoryItem Item,
+        Item Protocol,
+        uint Count,
+        bool IsNew
+    );
 }

--- a/Game/Starlight.Game.Player/InventoryModule.cs
+++ b/Game/Starlight.Game.Player/InventoryModule.cs
@@ -57,7 +57,8 @@ public sealed class InventoryModule(IPlayer player) : IModule
     public async Task<IReadOnlyList<MaterialItem>> AddMaterials(
         IEnumerable<uint> itemIds,
         uint count,
-        bool showHint = true)
+        bool showHint = true
+    )
     {
         LoadState();
         ArgumentOutOfRangeException.ThrowIfZero(count);
@@ -82,12 +83,13 @@ public sealed class InventoryModule(IPlayer player) : IModule
         uint amount = 1,
         uint level = 1,
         uint refinement = 1,
-        bool showHint = true)
+        bool showHint = true
+    )
     {
         LoadState();
         ArgumentOutOfRangeException.ThrowIfZero(amount);
-        level = Math.Clamp(level, 1u, 90u);
-        refinement = Math.Clamp(refinement, 1u, 5u);
+        level = Math.Clamp(level, min: 1u, max: 90u);
+        refinement = Math.Clamp(refinement, min: 1u, max: 5u);
 
         var changes = new List<AddedItem>();
 
@@ -115,9 +117,11 @@ public sealed class InventoryModule(IPlayer player) : IModule
         ulong guid,
         uint level = 1,
         uint refinement = 1,
-        bool showHint = true)
+        bool showHint = true
+    )
     {
         LoadState();
+
         if (_weapons.TryGetValue(guid, out var existing))
             return existing;
 
@@ -127,8 +131,8 @@ public sealed class InventoryModule(IPlayer player) : IModule
         var change = AddWeaponCore(
             data,
             guid,
-            Math.Clamp(level, 1u, 90u),
-            Math.Clamp(refinement, 1u, 5u));
+            Math.Clamp(level, min: 1u, max: 90u),
+            Math.Clamp(refinement, min: 1u, max: 5u));
 
         await NotifyAdded([change], showHint);
         return (WeaponItem)change.Item;
@@ -137,6 +141,7 @@ public sealed class InventoryModule(IPlayer player) : IModule
     public async Task<bool> RemoveMaterial(uint itemId, uint count)
     {
         LoadState();
+
         if (!_materials.TryGetValue(itemId, out var item) || count == 0 || item.Count < count)
             return false;
 
@@ -156,8 +161,7 @@ public sealed class InventoryModule(IPlayer player) : IModule
                     GuidList = { item.Guid }
                 });
             }
-        }
-        else
+        } else
         {
             _materialState[itemId].Count = item.Count;
 
@@ -233,6 +237,7 @@ public sealed class InventoryModule(IPlayer player) : IModule
         };
 
         _weapons.Add(guid, item);
+
         var state = new NetWeapon {
             ItemId = item.ItemId,
             Guid = item.Guid,
@@ -279,8 +284,8 @@ public sealed class InventoryModule(IPlayer player) : IModule
                 ItemId = state.ItemId,
                 Guid = state.Guid,
                 GadgetId = state.GadgetId,
-                Level = Math.Clamp(state.Level, 1u, 90u),
-                Refinement = Math.Clamp(state.Refinement, 1u, 5u),
+                Level = Math.Clamp(state.Level, min: 1u, max: 90u),
+                Refinement = Math.Clamp(state.Refinement, min: 1u, max: 5u),
                 PromoteLevel = state.PromoteLevel,
                 AffixId = state.AffixId
             });

--- a/Game/Starlight.Game.Player/InventoryModule.cs
+++ b/Game/Starlight.Game.Player/InventoryModule.cs
@@ -1,0 +1,336 @@
+using System.Diagnostics.CodeAnalysis;
+using Starlight.Game.Modules;
+using Starlight.Game.Resources.Excel;
+using Starlight.Protocol;
+using Starlight.Rpc.Proto;
+
+namespace Starlight.Game.Player;
+
+/// <summary>Owns one player's material stacks and equipment instances.</summary>
+public sealed class InventoryModule(IPlayer player) : IModule
+{
+    private const uint PackWeightLimit = 30000;
+    private const int MaterialCountLimit = 2000;
+    private const int WeaponCountLimit = 2000;
+    private const int NotifyChunkSize = 100;
+    private static readonly TimeSpan BulkNotifyInterval = TimeSpan.FromMilliseconds(25);
+
+    private readonly Dictionary<uint, MaterialItem> _materials = [];
+    private readonly Dictionary<ulong, WeaponItem> _weapons = [];
+    private readonly Dictionary<uint, NetMaterial> _materialState = [];
+    private readonly Dictionary<ulong, NetWeapon> _weaponState = [];
+
+    // The low range is currently occupied by starter avatars and their weapons. This partition
+    // keeps temporary inventory GUIDs separate until the allocator is persisted in DbGate.
+    private ulong _nextGuid = 0x20000000;
+    private bool _loaded;
+    private bool _loggedIn;
+
+    public IReadOnlyCollection<MaterialItem> Materials => _materials.Values;
+    public IReadOnlyCollection<WeaponItem> Weapons => _weapons.Values;
+
+    public bool TryGetMaterial(uint itemId, [NotNullWhen(true)] out MaterialItem? item)
+    {
+        LoadState();
+        return _materials.TryGetValue(itemId, out item);
+    }
+
+    public bool TryGetWeapon(ulong guid, [NotNullWhen(true)] out WeaponItem? item)
+    {
+        LoadState();
+        return _weapons.TryGetValue(guid, out item);
+    }
+
+    public async Task<MaterialItem> AddMaterial(uint itemId, uint count)
+    {
+        LoadState();
+        ArgumentOutOfRangeException.ThrowIfZero(count);
+
+        if (!_materials.ContainsKey(itemId) && _materials.Count >= MaterialCountLimit)
+            throw new InvalidOperationException("The material inventory is full.");
+
+        var change = AddMaterialCore(itemId, count);
+        await NotifyAdded([change]);
+        return (MaterialItem)change.Item;
+    }
+
+    public async Task<IReadOnlyList<MaterialItem>> AddMaterials(
+        IEnumerable<uint> itemIds,
+        uint count,
+        bool showHint = true)
+    {
+        LoadState();
+        ArgumentOutOfRangeException.ThrowIfZero(count);
+
+        var changes = new List<AddedItem>();
+
+        foreach (var itemId in itemIds.Distinct())
+        {
+            // Existing stacks can still be updated when every material slot is occupied.
+            if (!_materials.ContainsKey(itemId) && _materials.Count >= MaterialCountLimit)
+                continue;
+
+            changes.Add(AddMaterialCore(itemId, count));
+        }
+
+        await NotifyAdded(changes, showHint);
+        return [.. changes.Select(change => (MaterialItem)change.Item)];
+    }
+
+    public async Task<IReadOnlyList<WeaponItem>> AddWeapons(
+        IEnumerable<WeaponData> weapons,
+        uint amount = 1,
+        uint level = 1,
+        uint refinement = 1,
+        bool showHint = true)
+    {
+        LoadState();
+        ArgumentOutOfRangeException.ThrowIfZero(amount);
+        level = Math.Clamp(level, 1u, 90u);
+        refinement = Math.Clamp(refinement, 1u, 5u);
+
+        var changes = new List<AddedItem>();
+
+        foreach (var data in weapons)
+        {
+            for (var copy = 0u; copy < amount; copy++)
+            {
+                if (_weapons.Count >= WeaponCountLimit)
+                    break;
+
+                changes.Add(AddWeaponCore(data, NextGuid(), level, refinement));
+            }
+
+            if (_weapons.Count >= WeaponCountLimit)
+                break;
+        }
+
+        await NotifyAdded(changes, showHint);
+        return [.. changes.Select(change => (WeaponItem)change.Item)];
+    }
+
+    /// <summary>Adds an externally allocated weapon, such as an avatar's starter weapon.</summary>
+    public async Task<WeaponItem> AddWeapon(
+        WeaponData data,
+        ulong guid,
+        uint level = 1,
+        uint refinement = 1,
+        bool showHint = true)
+    {
+        LoadState();
+        if (_weapons.TryGetValue(guid, out var existing))
+            return existing;
+
+        if (_weapons.Count >= WeaponCountLimit)
+            throw new InvalidOperationException("The weapon inventory is full.");
+
+        var change = AddWeaponCore(
+            data,
+            guid,
+            Math.Clamp(level, 1u, 90u),
+            Math.Clamp(refinement, 1u, 5u));
+
+        await NotifyAdded([change], showHint);
+        return (WeaponItem)change.Item;
+    }
+
+    public async Task<bool> RemoveMaterial(uint itemId, uint count)
+    {
+        LoadState();
+        if (!_materials.TryGetValue(itemId, out var item) || count == 0 || item.Count < count)
+            return false;
+
+        item.Count -= count;
+
+        if (item.Count == 0)
+        {
+            _materials.Remove(itemId);
+
+            if (_materialState.Remove(itemId, out var state))
+                player.State.Materials.Remove(state);
+
+            if (_loggedIn)
+            {
+                await player.Send(new StoreItemDelNotify {
+                    StoreType = StoreType.STORE_TYPE_PACK,
+                    GuidList = { item.Guid }
+                });
+            }
+        }
+        else
+        {
+            _materialState[itemId].Count = item.Count;
+
+            if (_loggedIn)
+            {
+                await player.Send(new StoreItemChangeNotify {
+                    StoreType = StoreType.STORE_TYPE_PACK,
+                    ItemList = { item.ToProtocol() }
+                });
+            }
+        }
+
+        return true;
+    }
+
+    [Lifecycle(LifecycleEvent.PlayerLogin)]
+    public async Task OnLogin()
+    {
+        LoadState();
+
+        await player.Send(new StoreWeightLimitNotify {
+            StoreType = StoreType.STORE_TYPE_PACK,
+            MaterialCountLimit = MaterialCountLimit,
+            WeaponCountLimit = WeaponCountLimit,
+            ReliquaryCountLimit = 2000,
+            WeightLimit = PackWeightLimit
+        });
+
+        var items = _materials.Values.Select(item => item.ToProtocol())
+            .Concat(_weapons.Values.Select(item => item.ToProtocol()));
+
+        await player.Send(new PlayerStoreNotify {
+            StoreType = StoreType.STORE_TYPE_PACK,
+            WeightLimit = PackWeightLimit,
+            ItemList = [.. items]
+        });
+
+        _loggedIn = true;
+    }
+
+    private AddedItem AddMaterialCore(uint itemId, uint count)
+    {
+        if (!_materials.TryGetValue(itemId, out var item))
+        {
+            item = new MaterialItem {
+                ItemId = itemId,
+                Guid = NextGuid(),
+                Count = count
+            };
+
+            _materials.Add(itemId, item);
+            var state = new NetMaterial { ItemId = item.ItemId, Guid = item.Guid, Count = item.Count };
+            _materialState.Add(itemId, state);
+            player.State.Materials.Add(state);
+            return new AddedItem(item, count, IsNew: true);
+        }
+
+        item.Count = checked(item.Count + count);
+        _materialState[itemId].Count = item.Count;
+        return new AddedItem(item, count, IsNew: false);
+    }
+
+    private AddedItem AddWeaponCore(WeaponData data, ulong guid, uint level, uint refinement)
+    {
+        var item = new WeaponItem {
+            ItemId = data.Id,
+            Guid = guid,
+            GadgetId = data.GadgetId,
+            Level = level,
+            Refinement = refinement,
+            PromoteLevel = WeaponItem.PromoteLevelFor(level),
+            AffixId = data.SkillAffix.FirstOrDefault()
+        };
+
+        _weapons.Add(guid, item);
+        var state = new NetWeapon {
+            ItemId = item.ItemId,
+            Guid = item.Guid,
+            GadgetId = item.GadgetId,
+            Level = item.Level,
+            Refinement = item.Refinement,
+            PromoteLevel = item.PromoteLevel,
+            AffixId = item.AffixId
+        };
+        _weaponState.Add(guid, state);
+        player.State.Weapons.Add(state);
+        return new AddedItem(item, Count: 1, IsNew: true);
+    }
+
+    /// <summary>Hydrates the module once from the state DbGate attached to the player.</summary>
+    internal void LoadState()
+    {
+        if (_loaded)
+            return;
+
+        _loaded = true;
+
+        foreach (var state in player.State.Materials.Take(MaterialCountLimit))
+        {
+            if (state.ItemId == 0 || state.Guid == 0 || state.Count == 0
+                || _materials.ContainsKey(state.ItemId))
+                continue;
+
+            _materials.Add(state.ItemId, new MaterialItem {
+                ItemId = state.ItemId,
+                Guid = state.Guid,
+                Count = state.Count
+            });
+            _materialState.Add(state.ItemId, state);
+            AdvanceGuid(state.Guid);
+        }
+
+        foreach (var state in player.State.Weapons.Take(WeaponCountLimit))
+        {
+            if (state.ItemId == 0 || state.Guid == 0 || _weapons.ContainsKey(state.Guid))
+                continue;
+
+            _weapons.Add(state.Guid, new WeaponItem {
+                ItemId = state.ItemId,
+                Guid = state.Guid,
+                GadgetId = state.GadgetId,
+                Level = Math.Clamp(state.Level, 1u, 90u),
+                Refinement = Math.Clamp(state.Refinement, 1u, 5u),
+                PromoteLevel = state.PromoteLevel,
+                AffixId = state.AffixId
+            });
+            _weaponState.Add(state.Guid, state);
+            AdvanceGuid(state.Guid);
+        }
+    }
+
+    private void AdvanceGuid(ulong guid)
+    {
+        if ((uint)(guid >> 32) == player.Uid)
+            _nextGuid = Math.Max(_nextGuid, (uint)guid);
+    }
+
+    private async Task NotifyAdded(IEnumerable<AddedItem> added, bool showHint = true)
+    {
+        if (!_loggedIn)
+            return;
+
+        var chunks = added.Chunk(NotifyChunkSize).ToArray();
+
+        foreach (var (index, chunk) in chunks.Index())
+        {
+            await player.Send(new StoreItemChangeNotify {
+                StoreType = StoreType.STORE_TYPE_PACK,
+                ItemList = [.. chunk.Select(change => change.Item.ToProtocol())]
+            });
+
+            if (showHint)
+            {
+                await player.Send(new ItemAddHintNotify {
+                    Reason = (uint)ActionReasonType.ACTION_REASON_TYPE_GM,
+                    ItemList = [
+                        .. chunk.Select(change => new ItemHint {
+                            IsNew = change.IsNew,
+                            Guid = change.Item.Guid,
+                            ItemId = change.Item.ItemId,
+                            Count = change.Count
+                        })
+                    ]
+                });
+            }
+
+            // Give the client's inventory thread and KCP ACK path time to drain large grants.
+            if (chunks.Length > 1 && index < chunks.Length - 1)
+                await Task.Delay(BulkNotifyInterval, player.Closing);
+        }
+    }
+
+    private ulong NextGuid() => (ulong)player.Uid << 32 | ++_nextGuid;
+
+    private readonly record struct AddedItem(InventoryItem Item, uint Count, bool IsNew);
+}

--- a/Game/Starlight.Game.Player/WeaponItem.cs
+++ b/Game/Starlight.Game.Player/WeaponItem.cs
@@ -1,0 +1,56 @@
+using Starlight.Protocol;
+
+namespace Starlight.Game.Player;
+
+public sealed class WeaponItem : InventoryItem
+{
+    public uint GadgetId { get; init; }
+    public uint Level { get; init; } = 1;
+    public uint Refinement { get; init; } = 1;
+    public uint PromoteLevel { get; init; }
+    public uint AffixId { get; init; }
+
+    public override Item ToProtocol()
+    {
+        var weapon = new Weapon {
+            Level = Level,
+            PromoteLevel = PromoteLevel
+        };
+
+        if (AffixId != 0)
+            weapon.AffixMap[AffixId] = Refinement - 1;
+
+        return new Item {
+            ItemId = ItemId,
+            Guid = Guid,
+            Equip = new Equip { Weapon = weapon }
+        };
+    }
+
+    public SceneWeaponInfo ToSceneProtocol()
+    {
+        var weapon = new SceneWeaponInfo {
+            ItemId = ItemId,
+            Guid = Guid,
+            GadgetId = GadgetId,
+            Level = Level,
+            PromoteLevel = PromoteLevel,
+            AbilityInfo = new AbilitySyncStateInfo { IsInited = AffixId != 0 }
+        };
+
+        if (AffixId != 0)
+            weapon.AffixMap[AffixId] = Refinement - 1;
+
+        return weapon;
+    }
+
+    public static uint PromoteLevelFor(uint level) => level switch {
+        > 80 => 6,
+        > 70 => 5,
+        > 60 => 4,
+        > 50 => 3,
+        > 40 => 2,
+        > 20 => 1,
+        _ => 0
+    };
+}

--- a/Game/Starlight.Game.Resources/Excel/Avatars.cs
+++ b/Game/Starlight.Game.Resources/Excel/Avatars.cs
@@ -8,12 +8,9 @@ public sealed class AvatarData : Data
     [JsonPropertyName("id")]
     public new uint Id { get; set; }
 
-    /// Used for extracting the avatar's internal name.
-    /// Combined with avatar ability configs to look up the proper data.
     [JsonPropertyName("iconName")]
     public string IconName { get; set; } = string.Empty;
 
-    /// The ID of the default weapon the avatar spawns with.
     [JsonPropertyName("initialWeapon")]
     public uint InitialWeapon { get; set; }
 
@@ -35,9 +32,6 @@ public sealed class AvatarData : Data
     [JsonPropertyName("criticalHurt")]
     public float CritDamageBase { get; set; }
 
-    /// The internal name of the avatar comes at the end of the string.
-    /// <br/>
-    /// Example: <c>UI_AvatarIcon_[name]</c>
     public string AvatarName => IconName.Split('_').Last();
 }
 
@@ -52,6 +46,9 @@ public sealed class AvatarSkillDepotData : Data
 
     [JsonPropertyName("energySkill")]
     public uint EnergySkill { get; set; }
+
+    [JsonPropertyName("talents")]
+    public List<uint> Talents { get; set; } = [];
 
     [JsonPropertyName("talentStarName")]
     public string TalentStarName { get; set; } = string.Empty;

--- a/Game/Starlight.Game.Resources/Excel/Items.cs
+++ b/Game/Starlight.Game.Resources/Excel/Items.cs
@@ -10,4 +10,29 @@ public sealed class WeaponData : Data
 
     [JsonPropertyName("gadgetId")]
     public uint GadgetId { get; set; }
+
+    /// The passive affix carried by this weapon. It's map value is refinement - 1.
+    [JsonPropertyName("skillAffix")]
+    public List<uint> SkillAffix { get; set; } = [];
+}
+
+[GameResource("MaterialExcelConfigData.json")]
+public sealed class MaterialData : Data
+{
+    [JsonPropertyName("id")]
+    public new uint Id { get; set; }
+
+    [JsonPropertyName("stackLimit")]
+    public uint StackLimit { get; set; } = 1;
+
+    [JsonPropertyName("itemType")]
+    public string ItemType { get; set; } = "ITEM_MATERIAL";
+
+    [JsonPropertyName("materialType")]
+    public string MaterialType { get; set; } = string.Empty;
+
+    [JsonPropertyName("useOnGain")]
+    public bool UseOnGain { get; set; }
+
+    public bool IsInventoryMaterial => ItemType == "ITEM_MATERIAL" && !UseOnGain;
 }

--- a/Game/Starlight.Game.Resources/GameData.cs
+++ b/Game/Starlight.Game.Resources/GameData.cs
@@ -14,6 +14,7 @@ public sealed class GameData(IConfiguration config) : IHostedService
     [UsedImplicitly] public readonly Dictionary<uint, AvatarSkillDepotData> AvatarSkillDepotData = new();
     [UsedImplicitly] public readonly Dictionary<uint, AvatarTalentData> AvatarTalentData = new();
     [UsedImplicitly] public readonly Dictionary<uint, WeaponData> WeaponData = new();
+    [UsedImplicitly] public readonly Dictionary<uint, MaterialData> MaterialData = new();
     [UsedImplicitly] public readonly Dictionary<uint, CoopPointData> CoopPointData = new();
 
     #endregion

--- a/Libraries/Starlight.Common/GuidManager.cs
+++ b/Libraries/Starlight.Common/GuidManager.cs
@@ -1,43 +1,47 @@
-namespace Starlight.Common
+namespace Starlight.Common;
+
+/// <summary>
+/// Reimplementation of hk4e GuidMgr (gameserver/src/misc/guid_mgr.cpp).
+/// CB1 layout: [unix time:32][sequence low 12 bits:12][server id:8][0x1:type].
+/// Original code from KazusaGI CB1
+/// </summary>
+public sealed class GuidManager
 {
-    /// <summary>
-    /// Reimplementation of hk4e GuidMgr (gameserver/src/misc/guid_mgr.cpp).
-    /// CB1 layout: [unix time:32][sequence low 12 bits:12][server id:8][0x1:type].
-    /// Original code from KazusaGI CB1
-    /// </summary>
-    public sealed class GuidManager
+    public enum GuidType : uint
     {
-        public enum GuidType : uint
+        None = 0,
+        Avatar = 1,
+        Item = 2,
+        Mail = 3
+    }
+
+    private static readonly object SequenceLock = new();
+    private static uint _sequence;
+    private readonly uint _serverId;
+
+    public GuidManager(uint serverId = 1)
+    {
+        if (serverId > 0xFF)
+            throw new ArgumentOutOfRangeException(nameof(serverId), "hk4e GUID server id is 8-bit");
+
+        _serverId = serverId;
+    }
+
+    public ulong GenGuid(GuidType type)
+    {
+        uint seq;
+
+        lock (SequenceLock)
         {
-            None = 0,
-            Avatar = 1,
-            Item = 2,
-            Mail = 3,
+            seq = ++_sequence;
         }
 
-        private static readonly object SequenceLock = new();
-        private static uint _sequence;
-        private readonly uint _serverId;
+        var now = unchecked((uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
-        public GuidManager(uint serverId = 1)
-        {
-            if (serverId > 0xFF)
-                throw new ArgumentOutOfRangeException(nameof(serverId), "hk4e GUID server id is 8-bit");
-            _serverId = serverId;
-        }
-
-        public ulong GenGuid(GuidType type)
-        {
-            uint seq;
-            lock (SequenceLock)
-                seq = ++_sequence;
-
-            uint now = unchecked((uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
-            ulong low = ((ulong)(seq & 0xFFF) << 20)
-                        | ((ulong)(_serverId & 0xFF) << 12)
-                        | 0x10UL
-                        | ((ulong)type & 0xFUL);
-            return ((ulong)now << 32) | low;
-        }
+        var low = (ulong)(seq & 0xFFF) << 20
+                  | (ulong)(_serverId & 0xFF) << 12
+                  | 0x10UL
+                  | (ulong)type & 0xFUL;
+        return (ulong)now << 32 | low;
     }
 }

--- a/Libraries/Starlight.Common/GuidManager.cs
+++ b/Libraries/Starlight.Common/GuidManager.cs
@@ -1,0 +1,43 @@
+namespace Starlight.Common
+{
+    /// <summary>
+    /// Reimplementation of hk4e GuidMgr (gameserver/src/misc/guid_mgr.cpp).
+    /// CB1 layout: [unix time:32][sequence low 12 bits:12][server id:8][0x1:type].
+    /// Original code from KazusaGI CB1
+    /// </summary>
+    public sealed class GuidManager
+    {
+        public enum GuidType : uint
+        {
+            None = 0,
+            Avatar = 1,
+            Item = 2,
+            Mail = 3,
+        }
+
+        private static readonly object SequenceLock = new();
+        private static uint _sequence;
+        private readonly uint _serverId;
+
+        public GuidManager(uint serverId = 1)
+        {
+            if (serverId > 0xFF)
+                throw new ArgumentOutOfRangeException(nameof(serverId), "hk4e GUID server id is 8-bit");
+            _serverId = serverId;
+        }
+
+        public ulong GenGuid(GuidType type)
+        {
+            uint seq;
+            lock (SequenceLock)
+                seq = ++_sequence;
+
+            uint now = unchecked((uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+            ulong low = ((ulong)(seq & 0xFFF) << 20)
+                        | ((ulong)(_serverId & 0xFF) << 12)
+                        | 0x10UL
+                        | ((ulong)type & 0xFUL);
+            return ((ulong)now << 32) | low;
+        }
+    }
+}

--- a/Libraries/Starlight.Kcp/KcpConnection.cs
+++ b/Libraries/Starlight.Kcp/KcpConnection.cs
@@ -88,6 +88,7 @@ public sealed class KcpConnection
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(maxPendingSegments, other: 1);
 
+        // TODO: replace polling with signal-based wakeup
         while (PendingSendSegments >= maxPendingSegments)
         {
             ct.ThrowIfCancellationRequested();

--- a/Libraries/Starlight.Kcp/KcpConnection.cs
+++ b/Libraries/Starlight.Kcp/KcpConnection.cs
@@ -5,6 +5,8 @@ namespace Starlight.Kcp;
 
 public sealed class KcpConnection
 {
+    private const long DeadLinkGraceMilliseconds = 1000;
+
     private readonly Internals.Kcp _kcp;
 
     /// The KCP state is reached from three threads -- the socket receive loop, the 10ms update
@@ -18,11 +20,38 @@ public sealed class KcpConnection
     private readonly Action<KcpConnection, uint> _onDisconnect;
 
     private uint? _lingerReason;
+    private long? _deadLinkSince;
+    private bool _isDead;
 
     public IPEndPoint Remote { get; }
     public uint Conv => _kcp.Conv;
     public uint Token => _kcp.Token;
-    public bool IsDead => _kcp.State == -1;
+    /// <summary>
+    /// True once an unacknowledged dead-link condition has survived the recovery grace period.
+    /// KCP can hit its retransmit threshold during a burst just before the delayed ACK arrives.
+    /// </summary>
+    public bool IsDead
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _isDead;
+            }
+        }
+    }
+
+    /// <summary>The number of outbound segments waiting to be sent or acknowledged.</summary>
+    public int PendingSendSegments
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _kcp.SndQueue.Count + _kcp.SndBuf.Count;
+            }
+        }
+    }
 
     internal KcpConnection(
         uint conv,
@@ -47,6 +76,21 @@ public sealed class KcpConnection
         {
             _kcp.Send(data);
             FlushNow();
+        }
+    }
+
+    /// <summary>
+    /// Waits until KCP has room for another application packet. This keeps bulk producers from
+    /// building an unbounded send queue while the peer is still acknowledging an earlier window.
+    /// </summary>
+    public async Task WaitForSendCapacityAsync(int maxPendingSegments, CancellationToken ct = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxPendingSegments, 1);
+
+        while (PendingSendSegments >= maxPendingSegments)
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Delay(10, ct);
         }
     }
 
@@ -110,10 +154,38 @@ public sealed class KcpConnection
     internal void Update(long timestamp)
     {
         uint? drained = null;
+        var disconnected = false;
 
         lock (_gate)
         {
             _kcp.Update(timestamp);
+
+            if (_kcp.State == -1)
+            {
+                var hasDeadSegment = _kcp.SndBuf.Any(segment => segment.Xmit >= _kcp.DeadLink);
+
+                if (!hasDeadSegment)
+                {
+                    // The segment which reached DeadLink was acknowledged before the grace
+                    // period expired. Other packets may still be queued, but the link is alive.
+                    _kcp.State = 0;
+                    _deadLinkSince = null;
+                }
+                else
+                {
+                    _deadLinkSince ??= timestamp;
+
+                    if (timestamp - _deadLinkSince.Value >= DeadLinkGraceMilliseconds)
+                    {
+                        _isDead = true;
+                        disconnected = true;
+                    }
+                }
+            }
+            else
+            {
+                _deadLinkSince = null;
+            }
 
             // A pending graceful disconnect fires once the send buffers have drained,
             // i.e. the client has acked everything we queued before the kick.
@@ -130,7 +202,8 @@ public sealed class KcpConnection
             return;
         }
 
-        if (IsDead) _handler.OnDisconnected(this, (uint)DisconnectReason.ServerKillClient);
+        if (disconnected)
+            _handler.OnDisconnected(this, (uint)DisconnectReason.ServerKillClient);
     }
 
     private sealed class WriterAdapter(KcpConnection conn) : IWriter

--- a/Libraries/Starlight.Kcp/KcpConnection.cs
+++ b/Libraries/Starlight.Kcp/KcpConnection.cs
@@ -26,6 +26,7 @@ public sealed class KcpConnection
     public IPEndPoint Remote { get; }
     public uint Conv => _kcp.Conv;
     public uint Token => _kcp.Token;
+
     /// <summary>
     /// True once an unacknowledged dead-link condition has survived the recovery grace period.
     /// KCP can hit its retransmit threshold during a burst just before the delayed ACK arrives.
@@ -85,12 +86,12 @@ public sealed class KcpConnection
     /// </summary>
     public async Task WaitForSendCapacityAsync(int maxPendingSegments, CancellationToken ct = default)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxPendingSegments, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxPendingSegments, other: 1);
 
         while (PendingSendSegments >= maxPendingSegments)
         {
             ct.ThrowIfCancellationRequested();
-            await Task.Delay(10, ct);
+            await Task.Delay(millisecondsDelay: 10, ct);
         }
     }
 
@@ -170,8 +171,7 @@ public sealed class KcpConnection
                     // period expired. Other packets may still be queued, but the link is alive.
                     _kcp.State = 0;
                     _deadLinkSince = null;
-                }
-                else
+                } else
                 {
                     _deadLinkSince ??= timestamp;
 
@@ -181,8 +181,7 @@ public sealed class KcpConnection
                         disconnected = true;
                     }
                 }
-            }
-            else
+            } else
             {
                 _deadLinkSince = null;
             }

--- a/Libraries/Starlight.Protocol/Lifecycle.cs
+++ b/Libraries/Starlight.Protocol/Lifecycle.cs
@@ -9,9 +9,10 @@ namespace Starlight.Protocol;
 /// Handlers take no message, only the session player. Anything they return is sent to the client.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class LifecycleAttribute(LifecycleEvent @event) : Attribute
+public sealed class LifecycleAttribute(LifecycleEvent @event, LifecycleOrder order = LifecycleOrder.Normal) : Attribute
 {
     public LifecycleEvent Event => @event;
+    public LifecycleOrder Order => order;
 }
 
 public enum LifecycleEvent
@@ -19,5 +20,16 @@ public enum LifecycleEvent
     /// Sent once <c>PlayerLoginReq</c> has loaded the player's data, before <c>PlayerLoginRsp</c> goes out.
     PlayerLogin,
     /// Sent when the KCP session is dropped. The tunnel is gone by now, so sends are discarded.
-    PlayerDisconnect
+    PlayerDisconnect,
+    /// Sent when the player data is being saved to the database, before a PlayerDisconnect.
+    PlayerSaving
+}
+
+public enum LifecycleOrder
+{
+    First = -1000,
+    HighPriority = -500,
+    Normal = 0,
+    LowPriority = 500,
+    Last = 1000
 }

--- a/Libraries/Starlight.Rpc/Protobuf/starlight.player.proto
+++ b/Libraries/Starlight.Rpc/Protobuf/starlight.player.proto
@@ -12,6 +12,7 @@ message NetPlayer {
   // The account ID. Assigned by the SDK server.
   string account_id = 2;
   NetPlayerProfile profile = 3;
+  NetPlayerState state = 4;
 }
 
 message NetPlayerProfile {
@@ -19,6 +20,37 @@ message NetPlayerProfile {
   string signature = 2;
   uint32 picture_id = 3;
   uint32 name_card_id = 4;
+}
+
+message NetPlayerState {
+  repeated NetMaterial materials = 1;
+  repeated NetWeapon weapons = 2;
+  repeated NetAvatar avatars = 3;
+}
+
+message NetMaterial {
+  uint32 item_id = 1;
+  uint64 guid = 2;
+  uint32 count = 3;
+}
+
+message NetWeapon {
+  uint32 item_id = 1;
+  uint64 guid = 2;
+  uint32 level = 3;
+  uint32 refinement = 4;
+  uint32 promote_level = 5;
+  uint32 affix_id = 6;
+  uint32 gadget_id = 7;
+}
+
+message NetAvatar {
+  uint32 avatar_id = 1;
+  uint64 guid = 2;
+  uint32 level = 3;
+  uint32 constellation = 4;
+  uint32 born_time = 5;
+  uint64 weapon_guid = 6;
 }
 
 // --- MESSAGES START --- \\
@@ -44,6 +76,19 @@ message FetchPlayerReq {
 message FetchPlayerRsp {
   StarlightRetcode retcode = 1;
   optional NetPlayer player = 2;
+}
+
+// Path: Game Server -> DB Gate
+// Subject: `game.player.save`
+message SavePlayerReq {
+  uint32 uid = 1;
+  NetPlayerState state = 2;
+}
+
+// Path: DB Gate -> Game Server
+// Subject: `game.player.save`
+message SavePlayerRsp {
+  StarlightRetcode retcode = 1;
 }
 
 // Sent as a metadata payload for informing the game server

--- a/Libraries/Starlight.Rpc/RpcSubjects.cs
+++ b/Libraries/Starlight.Rpc/RpcSubjects.cs
@@ -13,6 +13,7 @@ public static class GameSubjects
     public const string Disconnect = "game.gate.disconnect";
 
     public const string FetchPlayer = "game.player.fetch";
+    public const string SavePlayer = "game.player.save";
 }
 
 public static class GateSubjects

--- a/Source/Starlight.DbGate/DbGateService.cs
+++ b/Source/Starlight.DbGate/DbGateService.cs
@@ -20,6 +20,7 @@ public sealed class DbGateService(
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _subscriptions.Add(await rpc.Subscribe<FetchPlayerReq>(GameSubjects.FetchPlayer, players.Fetch));
+        _subscriptions.Add(await rpc.Subscribe<SavePlayerReq>(GameSubjects.SavePlayer, players.Save));
         logger.LogInformation("DB Gate is now listening for requests...");
     }
 
@@ -40,6 +41,7 @@ public static class ServiceExtensions
         var config = builder.Configuration.GetSection("DbGate").Get<DbGateConfig>() ?? new DbGateConfig();
 
         builder.Services
+            .AddHostedService<PlayerStateSchemaUpgradeService>()
             .AddStarlightDbContext<StarlightDbContext>(config)
             .AddSingleton<PlayerService>()
             .AddHostedService<DbGateService>();

--- a/Source/Starlight.DbGate/Models/Player.cs
+++ b/Source/Starlight.DbGate/Models/Player.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Google.Protobuf;
 using Microsoft.EntityFrameworkCore;
 using Starlight.Rpc;
 using Starlight.Rpc.Proto;
@@ -21,9 +22,13 @@ public sealed record Player : IRpcSerializable<NetPlayer>
 
     public PlayerProfile Profile { get; set; } = new();
 
+    /// <summary>Opaque game-owned state. DbGate stores it without knowing module internals.</summary>
+    public byte[] State { get; set; } = [];
+
     public NetPlayer Serialize() => new() {
         Uid = Id,
         AccountId = AccountId,
-        Profile = Profile.Serialize()
+        Profile = Profile.Serialize(),
+        State = State.Length == 0 ? new NetPlayerState() : NetPlayerState.Parser.ParseFrom(State)
     };
 }

--- a/Source/Starlight.DbGate/Services/PlayerService.cs
+++ b/Source/Starlight.DbGate/Services/PlayerService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Google.Protobuf;
 using Starlight.Database;
 using Starlight.DbGate.Models;
 using Starlight.Rpc;
@@ -83,5 +84,31 @@ public sealed class PlayerService(IServiceScopeFactory scopes, ILogger<PlayerSer
             Retcode = StarlightRetcode.Success,
             Player = player.Serialize()
         });
+    }
+
+    public async Task Save(SavePlayerReq msg, RpcMessage rpc)
+    {
+        using var scope = scopes.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<StarlightDbContext>();
+
+        var player = await db.Players.FirstOrDefaultAsync(player => player.Id == msg.Uid);
+
+        if (player is null)
+        {
+            await rpc.Reply(new SavePlayerRsp { Retcode = StarlightRetcode.PlayerNotFound });
+            return;
+        }
+
+        try
+        {
+            player.State = (msg.State ?? new NetPlayerState()).ToByteArray();
+            await db.SaveChangesAsync();
+            await rpc.Reply(new SavePlayerRsp { Retcode = StarlightRetcode.Success });
+        }
+        catch (DbUpdateException ex)
+        {
+            logger.LogError(ex, "Failed to save player '{PlayerId}'", msg.Uid);
+            await rpc.Reply(new SavePlayerRsp { Retcode = StarlightRetcode.ServerError });
+        }
     }
 }

--- a/Source/Starlight.DbGate/StarlightDbContext.cs
+++ b/Source/Starlight.DbGate/StarlightDbContext.cs
@@ -3,6 +3,8 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog.Core;
 using Starlight.DbGate.Models;
 
 namespace Starlight.DbGate;
@@ -47,7 +49,7 @@ public sealed class StarlightDbContext(DbContextOptions options) : DbContext(opt
 /// Preserves early-development databases when player state is introduced. The generic schema
 /// checker intentionally archives drifted files, but this change is safely additive.
 /// </summary>
-internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scopes) : IHostedService
+internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scopes, ILogger logger) : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -93,9 +95,13 @@ internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scope
                     cancellationToken);
             }
         }
-        catch (SqliteException)
+        catch (SqliteException ex) when (ex.SqliteErrorCode == 1) // SQLITE_ERROR
         {
             // Let the normal schema service produce its detailed drift/startup error.
+        }
+        catch (SqliteException ex)
+        {
+            logger.LogWarning(ex, "Player state schema upgrade failed, falling back to the generic schema service.");
         }
         finally
         {

--- a/Source/Starlight.DbGate/StarlightDbContext.cs
+++ b/Source/Starlight.DbGate/StarlightDbContext.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Starlight.DbGate.Models;
 
 namespace Starlight.DbGate;
@@ -38,4 +41,65 @@ public sealed class StarlightDbContext(DbContextOptions options) : DbContext(opt
         modelBuilder.Entity<Player>()
             .HasAlternateKey(p => p.AccountId);
     }
+}
+
+/// <summary>
+/// Preserves early-development databases when player state is introduced. The generic schema
+/// checker intentionally archives drifted files, but this change is safely additive.
+/// </summary>
+internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scopes) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = scopes.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<StarlightDbContext>();
+
+        if (!db.Database.IsSqlite())
+            return;
+
+        await db.Database.OpenConnectionAsync(cancellationToken);
+
+        try
+        {
+            await using var tableCommand = db.Database.GetDbConnection().CreateCommand();
+            tableCommand.CommandText =
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'Players';";
+
+            if (Convert.ToInt32(await tableCommand.ExecuteScalarAsync(cancellationToken)) == 0)
+                return;
+
+            await using var columnsCommand = db.Database.GetDbConnection().CreateCommand();
+            columnsCommand.CommandText = "SELECT name FROM pragma_table_info('Players');";
+
+            var hasState = false;
+            await using (var reader = await columnsCommand.ExecuteReaderAsync(cancellationToken))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    if (reader.GetString(0).Equals("State", StringComparison.OrdinalIgnoreCase))
+                    {
+                        hasState = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasState)
+            {
+                await db.Database.ExecuteSqlRawAsync(
+                    "ALTER TABLE Players ADD COLUMN State BLOB NOT NULL DEFAULT X'';",
+                    cancellationToken);
+            }
+        }
+        catch (SqliteException)
+        {
+            // Let the normal schema service produce its detailed drift/startup error.
+        }
+        finally
+        {
+            await db.Database.CloseConnectionAsync();
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/Source/Starlight.DbGate/StarlightDbContext.cs
+++ b/Source/Starlight.DbGate/StarlightDbContext.cs
@@ -62,6 +62,7 @@ internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scope
         try
         {
             await using var tableCommand = db.Database.GetDbConnection().CreateCommand();
+
             tableCommand.CommandText =
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'Players';";
 
@@ -72,6 +73,7 @@ internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scope
             columnsCommand.CommandText = "SELECT name FROM pragma_table_info('Players');";
 
             var hasState = false;
+
             await using (var reader = await columnsCommand.ExecuteReaderAsync(cancellationToken))
             {
                 while (await reader.ReadAsync(cancellationToken))

--- a/Source/Starlight.Game/GameServerService.cs
+++ b/Source/Starlight.Game/GameServerService.cs
@@ -94,6 +94,7 @@ public static class GameServerExtensions
 
         builder.Services
             .AddSingleton(registry)
+            .AddSingleton<PlayerManager>()
             .AddHostedService<GameServerService>();
         return builder;
     }

--- a/Source/Starlight.Game/Modules/ModuleRegistry.cs
+++ b/Source/Starlight.Game/Modules/ModuleRegistry.cs
@@ -59,7 +59,7 @@ public sealed class ModuleRegistry
     }
 
     /// <summary>Registers a handler for <paramref name="event"/> living on <typeparamref name="TModule"/>.</summary>
-    public void AddLifecycle<TModule>(LifecycleEvent @event, LifecycleHandler handler)
+    public void AddLifecycle<TModule>(LifecycleEvent @event, LifecycleOrder order, LifecycleHandler handler)
         where TModule : class, IModule
     {
         ThrowIfImmutable();
@@ -67,7 +67,17 @@ public sealed class ModuleRegistry
         if (!_lifecycles.TryGetValue(@event, out var list))
             _lifecycles[@event] = list = [];
 
-        list.Add(new PendingLifecycle(typeof(TModule), handler));
+        list.Add(new PendingLifecycle(typeof(TModule), order, handler));
+    }
+
+    /// <summary>Compatibility for callers that don't specify an order</summary>
+    public void AddLifecycle<TModule>(
+        LifecycleEvent @event,
+        LifecycleHandler handler
+    )
+        where TModule : class, IModule
+    {
+        AddLifecycle<TModule>(@event, LifecycleOrder.Normal, handler);
     }
 
     /// <summary>Freezes the registry into its read-only lookup form, returning it. Call once, after all components register.</summary>
@@ -78,11 +88,20 @@ public sealed class ModuleRegistry
 
         _table = _handlers.ToFrozenDictionary(
             pair => pair.Key,
-            pair => pair.Value.Select(h => new CompiledHandler(Resolve(h.ModuleType), h.Handler)).ToArray());
+            pair => pair.Value
+                .Select(handler => new CompiledHandler(
+                    Resolve(handler.ModuleType),
+                    handler.Handler))
+                .ToArray());
 
         _lifecycleTable = _lifecycles.ToFrozenDictionary(
             pair => pair.Key,
-            pair => pair.Value.Select(h => new CompiledLifecycle(Resolve(h.ModuleType), h.Handler)).ToArray());
+            pair => pair.Value
+                .OrderBy(handler => handler.Order)
+                .Select(handler => new CompiledLifecycle(
+                    Resolve(handler.ModuleType),
+                    handler.Handler))
+                .ToArray());
 
         Immutable = true;
 
@@ -148,7 +167,7 @@ public sealed class ModuleRegistry
 
     private readonly record struct PendingHandler(Type ModuleType, ModuleHandler Handler);
 
-    private readonly record struct PendingLifecycle(Type ModuleType, LifecycleHandler Handler);
+    private readonly record struct PendingLifecycle(Type ModuleType, LifecycleOrder Order, LifecycleHandler Handler);
 
     private readonly record struct CompiledHandler(int ModuleIndex, ModuleHandler Invoke);
 

--- a/Source/Starlight.Game/Player/IPlayer.cs
+++ b/Source/Starlight.Game/Player/IPlayer.cs
@@ -1,5 +1,6 @@
 using Starlight.Game.Modules;
 using Starlight.Protocol;
+using Starlight.Rpc.Proto;
 using IMessage = Starlight.Protobuf.Core.IMessage;
 
 namespace Starlight.Game.Player;
@@ -11,6 +12,12 @@ public interface IPlayer
     /// The SDK account behind this player. Set from the gate's connect notify, since the
     /// account uid on PlayerLoginReq comes through empty.
     string AccountUid { get; internal set; }
+
+    /// <summary>Fires when the player's gate tunnel closes.</summary>
+    CancellationToken Closing { get; }
+
+    /// <summary>Game-owned state loaded from and saved through DbGate.</summary>
+    NetPlayerState State { get; internal set; }
 
     /// <summary>Resolves this player's instance of <typeparamref name="TModule"/>.</summary>
     TModule Module<TModule>() where TModule : class, IModule;

--- a/Source/Starlight.Game/Player/IPlayer.cs
+++ b/Source/Starlight.Game/Player/IPlayer.cs
@@ -19,6 +19,9 @@ public interface IPlayer
     /// <summary>Game-owned state loaded from and saved through DbGate.</summary>
     NetPlayerState State { get; internal set; }
 
+    /// <summary>Synchronizes access to this player's live module and persisted state.</summary>
+    object StateLock { get; }
+
     /// <summary>Resolves this player's instance of <typeparamref name="TModule"/>.</summary>
     TModule Module<TModule>() where TModule : class, IModule;
 

--- a/Source/Starlight.Game/Player/PlayerManager.cs
+++ b/Source/Starlight.Game/Player/PlayerManager.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Starlight.Game.Player;
+
+/// <summary>
+/// Players currently logged in to this game server, keyed by their region UID.
+/// Persistent player data remains owned by DbGate; this only tracks live sessions.
+/// </summary>
+public sealed class PlayerManager
+{
+    private readonly ConcurrentDictionary<uint, IPlayer> _players = [];
+
+    /// <summary>The number of players currently logged in.</summary>
+    public int Count => _players.Count;
+
+    /// <summary>Finds the live player with <paramref name="uid"/>.</summary>
+    public bool TryGet(uint uid, [MaybeNullWhen(false)] out IPlayer player)
+        => _players.TryGetValue(uid, out player);
+
+    /// <summary>
+    /// Registers <paramref name="player"/> as online. Returns <c>false</c> when another
+    /// live session already owns the same UID.
+    /// </summary>
+    public bool Add(IPlayer player) => _players.TryAdd(player.Uid, player);
+
+    /// <summary>
+    /// Removes this exact player session. Matching the instance as well as the UID prevents
+    /// a delayed disconnect from removing a newer session for the same player.
+    /// </summary>
+    public bool Remove(IPlayer player)
+        => ((ICollection<KeyValuePair<uint, IPlayer>>)_players)
+            .Remove(new KeyValuePair<uint, IPlayer>(player.Uid, player));
+
+    /// <summary>Returns a stable snapshot for commands and broadcasts to enumerate.</summary>
+    public IReadOnlyList<IPlayer> Snapshot() => [.. _players.Values];
+}

--- a/Source/Starlight.Game/Player/PlayerModule.cs
+++ b/Source/Starlight.Game/Player/PlayerModule.cs
@@ -14,7 +14,8 @@ public sealed class PlayerModule(
     RpcTransport rpc,
     PlayerManager players,
     ILogger<PlayerModule> logger,
-    IPlayer player) : IModule
+    IPlayer player
+) : IModule
 {
     /// <summary>
     /// Authenticates the player and loads their data, then hands off to every

--- a/Source/Starlight.Game/Player/PlayerModule.cs
+++ b/Source/Starlight.Game/Player/PlayerModule.cs
@@ -1,3 +1,4 @@
+using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Starlight.Game.Modules;
 using Starlight.Kcp;
@@ -17,6 +18,8 @@ public sealed class PlayerModule(
     IPlayer player
 ) : IModule
 {
+    private bool _removedFromPlayerManager;
+
     /// <summary>
     /// Authenticates the player and loads their data, then hands off to every
     /// <see cref="LifecycleEvent.PlayerLogin"/> handler before answering the client.
@@ -42,7 +45,11 @@ public sealed class PlayerModule(
 
             // Set player properties.
             player.Uid = data.Uid;
-            player.State = data.State ?? new NetPlayerState();
+
+            lock (player.StateLock)
+            {
+                player.State = data.State ?? new NetPlayerState();
+            }
             nickname = data.Profile?.Nickname ?? string.Empty;
 
             if (!players.Add(player))
@@ -89,28 +96,57 @@ public sealed class PlayerModule(
         };
     }
 
-    [Lifecycle(LifecycleEvent.PlayerDisconnect)]
-    public async Task OnDisconnect()
+    [Lifecycle(LifecycleEvent.PlayerSaving, LifecycleOrder.First)]
+    public async Task OnSaving()
     {
-        // A rejected duplicate session must not overwrite the live session's state.
+        // Only the registered session may persist this player's state.
+        // A rejected duplicate session will fail this exact-instance removal.
         if (!players.Remove(player))
             return;
 
+        _removedFromPlayerManager = true;
+
         try
         {
+            NetPlayerState state;
+
+            lock (player.StateLock)
+            {
+                state = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+            }
+
             var response = await rpc.Request<SavePlayerReq, SavePlayerRsp>(
                 GameSubjects.SavePlayer,
-                new SavePlayerReq { Uid = player.Uid, State = player.State });
+                new SavePlayerReq {
+                    Uid = player.Uid,
+                    State = state
+                });
 
             if (response.Retcode != StarlightRetcode.Success)
-                logger.LogError("Failed to save player '{PlayerId}': {Retcode}", player.Uid, response.Retcode);
+            {
+                logger.LogError(
+                    "Failed to save player '{PlayerId}': {Retcode}",
+                    player.Uid,
+                    response.Retcode);
+            }
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to save player '{PlayerId}' during disconnect", player.Uid);
+            logger.LogError(
+                ex,
+                "Failed to save player '{PlayerId}' during disconnect",
+                player.Uid);
         }
+    }
 
-        logger.LogInformation("Player '{PlayerId}' logged out.", player.Uid);
+    [Lifecycle(LifecycleEvent.PlayerDisconnect, LifecycleOrder.First)]
+    public Task OnDisconnect()
+    {
+        // Do not report rejected duplicate sessions as logged out.
+        if (_removedFromPlayerManager)
+            logger.LogInformation("Player '{PlayerId}' logged out.", player.Uid);
+
+        return Task.CompletedTask;
     }
 
     /// <summary>Unlocks everything the client gates behind an open state.</summary>

--- a/Source/Starlight.Game/Player/PlayerModule.cs
+++ b/Source/Starlight.Game/Player/PlayerModule.cs
@@ -10,7 +10,11 @@ namespace Starlight.Game.Player;
 /// <summary>
 /// Primary data operations module used across everything.
 /// </summary>
-public sealed class PlayerModule(RpcTransport rpc, ILogger<PlayerModule> logger, IPlayer player) : IModule
+public sealed class PlayerModule(
+    RpcTransport rpc,
+    PlayerManager players,
+    ILogger<PlayerModule> logger,
+    IPlayer player) : IModule
 {
     /// <summary>
     /// Authenticates the player and loads their data, then hands off to every
@@ -37,7 +41,16 @@ public sealed class PlayerModule(RpcTransport rpc, ILogger<PlayerModule> logger,
 
             // Set player properties.
             player.Uid = data.Uid;
+            player.State = data.State ?? new NetPlayerState();
             nickname = data.Profile?.Nickname ?? string.Empty;
+
+            if (!players.Add(player))
+            {
+                logger.LogWarning("Rejected a second session for player '{PlayerId}'.", player.Uid);
+
+                throw new KickException(DisconnectReason.ServerKick,
+                    new PlayerLoginRsp { Retcode = (int)Retcode.RETCODE_REPEAT_LOGIN });
+            }
 
             logger.LogInformation("Player '{PlayerId}' logged in.", player.Uid);
         }
@@ -73,6 +86,30 @@ public sealed class PlayerModule(RpcTransport rpc, ILogger<PlayerModule> logger,
             GameBiz = "hk4e_global",
             CountryCode = "US"
         };
+    }
+
+    [Lifecycle(LifecycleEvent.PlayerDisconnect)]
+    public async Task OnDisconnect()
+    {
+        // A rejected duplicate session must not overwrite the live session's state.
+        if (!players.Remove(player))
+            return;
+
+        try
+        {
+            var response = await rpc.Request<SavePlayerReq, SavePlayerRsp>(
+                GameSubjects.SavePlayer,
+                new SavePlayerReq { Uid = player.Uid, State = player.State });
+
+            if (response.Retcode != StarlightRetcode.Success)
+                logger.LogError("Failed to save player '{PlayerId}': {Retcode}", player.Uid, response.Retcode);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to save player '{PlayerId}' during disconnect", player.Uid);
+        }
+
+        logger.LogInformation("Player '{PlayerId}' logged out.", player.Uid);
     }
 
     /// <summary>Unlocks everything the client gates behind an open state.</summary>

--- a/Source/Starlight.Game/Player/StarlightPlayer.cs
+++ b/Source/Starlight.Game/Player/StarlightPlayer.cs
@@ -4,6 +4,7 @@ using Starlight.Game.Modules;
 using Starlight.Kcp;
 using Starlight.Protocol;
 using Starlight.Rpc;
+using Starlight.Rpc.Proto;
 using Starlight.Rpc.Tunnel;
 using IMessage = Starlight.Protobuf.Core.IMessage;
 
@@ -26,6 +27,8 @@ public sealed class StarlightPlayer : IPlayer
 
     public uint Uid { get; set; }
     public string AccountUid { get; set; } = string.Empty;
+    public CancellationToken Closing => _tunnel.Closed;
+    public NetPlayerState State { get; set; } = new();
 
     /// <inheritdoc/>
     public TModule Module<TModule>() where TModule : class, IModule

--- a/Source/Starlight.Game/Player/StarlightPlayer.cs
+++ b/Source/Starlight.Game/Player/StarlightPlayer.cs
@@ -29,6 +29,7 @@ public sealed class StarlightPlayer : IPlayer
     public string AccountUid { get; set; } = string.Empty;
     public CancellationToken Closing => _tunnel.Closed;
     public NetPlayerState State { get; set; } = new();
+    public object StateLock { get; } = new();
 
     /// <inheritdoc/>
     public TModule Module<TModule>() where TModule : class, IModule
@@ -73,6 +74,15 @@ public sealed class StarlightPlayer : IPlayer
     /// <summary>Runs the disconnect lifecycle. The tunnel is already gone, so faults can only be logged.</summary>
     internal async Task Close()
     {
+        try
+        {
+            await Emit(LifecycleEvent.PlayerSaving);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled error saving player '{PlayerId}'", Uid);
+        }
+
         try
         {
             await Emit(LifecycleEvent.PlayerDisconnect);

--- a/Source/Starlight.Gate/GateServerService.cs
+++ b/Source/Starlight.Gate/GateServerService.cs
@@ -120,7 +120,13 @@ public sealed class GateServerService(
             session.OnClose(reason);
         }
 
-        logger.LogDebug("Client disconnected: {Remote} (conv={Conv})", conn.Remote, conn.Conv);
+        logger.LogInformation(
+            "Client disconnected: {Remote} (conv={Conv}, reason={Reason}, reasonCode={ReasonCode}, pendingSendSegments={PendingSendSegments})",
+            conn.Remote,
+            conn.Conv,
+            (DisconnectReason)reason,
+            reason,
+            conn.PendingSendSegments);
     }
 
     public void OnReceive(KcpConnection conn, byte[] data)

--- a/Source/Starlight.Gate/Session/INetworkSession.cs
+++ b/Source/Starlight.Gate/Session/INetworkSession.cs
@@ -52,6 +52,9 @@ public interface INetworkSession
     /// Sends a message to the connected client, optionally with a <see cref="PacketHead"/>.
     void Send(IMessage message, PacketHead? metadata = null);
 
+    /// Sends after waiting for capacity in the reliable transport's outbound window.
+    Task SendAsync(IMessage message, PacketHead? metadata = null);
+
     /// Drops the client with <paramref name="reason"/>. When <paramref name="flush"/> is set, the
     /// connection lingers until all queued packets are acknowledged so a final packet is delivered.
     void Disconnect(uint reason, bool flush);

--- a/Source/Starlight.Gate/Session/Modules/LoginModule.cs
+++ b/Source/Starlight.Gate/Session/Modules/LoginModule.cs
@@ -84,9 +84,15 @@ public sealed class LoginModule(INetworkSession session)
             GameSubjects.GateConnection, sessionInfo, ReplyTimeout, ct: session.Closing);
 
         // Relay packets the game server emits back down to the client.
-        _ = gameTunnel.Subscribe(GameSubjects.OutboundPacket, raw => {
-            session.Send(raw.Decode<Starlight.Protobuf.Core.IMessage>());
-            return Task.CompletedTask;
+        _ = gameTunnel.Subscribe(GameSubjects.OutboundPacket, async raw => {
+            try
+            {
+                await session.SendAsync(raw.Decode<Starlight.Protobuf.Core.IMessage>());
+            }
+            catch (OperationCanceledException) when (session.Closing.IsCancellationRequested)
+            {
+                // The connection closed while this packet was waiting for transport capacity.
+            }
         });
 
         // Drop the client when the game server asks us to.

--- a/Source/Starlight.Gate/Session/StarlightSession.cs
+++ b/Source/Starlight.Gate/Session/StarlightSession.cs
@@ -21,6 +21,7 @@ public sealed class StarlightSession : INetworkSession
     /// A client that outruns <see cref="ConsumeInbound"/> gets dropped rather than growing
     /// the queue until the process runs out of memory.
     private const int MaxQueuedPackets = 1024;
+    private const int MaxPendingSendSegments = 32;
 
     private readonly KcpConnection _connection;
 
@@ -244,6 +245,12 @@ public sealed class StarlightSession : INetworkSession
             CryptoHelper.Xor(bytes, _xorPad);
             _connection.Send(bytes);
         }
+    }
+
+    public async Task SendAsync(IMessage message, PacketHead? metadata = null)
+    {
+        await _connection.WaitForSendCapacityAsync(MaxPendingSendSegments, Closing);
+        Send(message, metadata);
     }
 
     public void Disconnect(uint reason, bool flush)

--- a/Source/Starlight/Commands/GiveCommand.cs
+++ b/Source/Starlight/Commands/GiveCommand.cs
@@ -1,0 +1,300 @@
+using Serilog;
+using Starlight.Game.Player;
+using Starlight.Game.Resources;
+using Starlight.Rpc.Tunnel;
+
+namespace Starlight.Commands;
+
+public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
+{
+    public string Name => "give";
+    public string Description => "Gives materials, weapons, or avatars to an online player.";
+    public string Usage =>
+        "give <uid> <item-id|avatar-id|all|weapons|materials|avatars> [x<count>] [lvl<level>] [r<1-5>] [c<0-6>]";
+
+    public string[] Aliases => ["g", "item", "giveitem"];
+
+    public async Task ExecuteAsync(string[] args, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ExecuteCoreAsync(args, cancellationToken);
+        }
+        catch (TunnelClosedException)
+        {
+            Log.Warning("Give stopped because the target player disconnected.");
+        }
+    }
+
+    private async Task ExecuteCoreAsync(string[] args, CancellationToken cancellationToken)
+    {
+        if (args.Length < 2 || !uint.TryParse(args[0], out var uid) || uid == 0)
+        {
+            Log.Warning("Usage: {Usage}", Usage);
+            return;
+        }
+
+        if (!players.TryGet(uid, out var player))
+        {
+            Log.Warning("Player '{PlayerId}' is not online.", uid);
+            return;
+        }
+
+        if (!TryParseOptions(args[2..], out var options, out var error))
+        {
+            Log.Warning("{Error} Usage: {Usage}", error, Usage);
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var selector = args[1].ToLowerInvariant();
+        var inventory = player.Module<InventoryModule>();
+
+        switch (selector)
+        {
+            case "all":
+                await GiveMaterials(inventory, options);
+                cancellationToken.ThrowIfCancellationRequested();
+                await GiveWeapons(inventory, options);
+                cancellationToken.ThrowIfCancellationRequested();
+                await GiveAvatars(
+                    player.Module<AvatarModule>(), options, defaultConstellation: 6);
+                return;
+
+            case "weapons":
+            case "weapon":
+            case "wp":
+                await GiveWeapons(inventory, options);
+                return;
+
+            case "materials":
+            case "material":
+            case "mats":
+            case "mat":
+                await GiveMaterials(inventory, options);
+                return;
+
+            case "avatars":
+            case "avatar":
+                await GiveAvatars(
+                    player.Module<AvatarModule>(), options, defaultConstellation: 6);
+                return;
+        }
+
+        if (!uint.TryParse(selector, out var id) || id == 0)
+        {
+            Log.Warning("'{Selector}' is not an item ID, avatar ID, or supported selector.", selector);
+            return;
+        }
+
+        if (data.MaterialData.TryGetValue(id, out var material) && material.IsInventoryMaterial)
+        {
+            await inventory.AddMaterial(id, options.Amount);
+            return;
+        }
+
+        if (data.WeaponData.TryGetValue(id, out var weapon))
+        {
+            await inventory.AddWeapons(
+                [weapon],
+                amount: options.Amount,
+                level: options.Level,
+                refinement: options.Refinement);
+            return;
+        }
+
+        if (CanCreateAvatar(id))
+        {
+            await player.Module<AvatarModule>().AddAvatar(id, options.Level, options.Constellation);
+            return;
+        }
+
+        Log.Warning("No supported material, weapon, or avatar has ID {Id}.", id);
+    }
+
+    private async Task<int> GiveMaterials(InventoryModule inventory, GiveOptions options)
+    {
+        var ids = data.MaterialData.Values
+            .Where(material => material.Id >= 100000
+                               && material.IsInventoryMaterial
+                               && !IsIllegalMaterial(material.Id))
+            .Select(material => material.Id)
+            .Order();
+
+        var items = await inventory.AddMaterials(ids, options.Amount, showHint: false);
+        return items.Count;
+    }
+
+    // These resource rows are placeholders, internal-use items, or known to produce invalid
+    // inventory entries.
+    private static bool IsIllegalMaterial(uint id)
+        => id is 100086 or 100087 or 105001 or 105004 or 107011 or 108000
+            or 220050 or 220054
+           || id is >= 100100 and <= 101000
+           || id is >= 101106 and <= 101110
+           || id is >= 101500 and <= 104000
+           || id is >= 106000 and <= 107000
+           || id is >= 109000 and <= 110000
+           || id is >= 115000 and <= 130000
+           || id is >= 200200 and <= 200899;
+
+    private async Task<int> GiveWeapons(InventoryModule inventory, GiveOptions options)
+    {
+        var resources = data.WeaponData.Values
+            .Where(weapon => weapon.Id is >= 11100 and <= 16000)
+            .OrderBy(weapon => weapon.Id);
+
+        var amount = Math.Min(options.Amount, 5u);
+        var items = await inventory.AddWeapons(
+            resources,
+            amount,
+            options.Level,
+            options.Refinement,
+            showHint: false);
+        return items.Count;
+    }
+
+    private async Task<int> GiveAvatars(
+        AvatarModule avatars,
+        GiveOptions options,
+        uint defaultConstellation)
+    {
+        var constellation = options.HasConstellation ? options.Constellation : defaultConstellation;
+        var count = 0;
+
+        foreach (var avatarId in data.AvatarData.Keys
+                     .Where(id => id is >= 10000002 and < 11000000)
+                     .Where(CanCreateAvatar)
+                     .Order())
+        {
+            var (_, added) = await avatars.AddAvatar(avatarId, options.Level, constellation);
+            if (added)
+                count++;
+        }
+
+        return count;
+    }
+
+    private bool CanCreateAvatar(uint avatarId)
+    {
+        if (!data.AvatarData.TryGetValue(avatarId, out var avatar))
+            return false;
+
+        return data.AvatarSkillDepotData.ContainsKey(avatar.SkillDepotId)
+               && data.WeaponData.ContainsKey(avatar.InitialWeapon)
+               && data.Avatars.ContainsKey(avatarId);
+    }
+
+    private static bool TryParseOptions(string[] args, out GiveOptions options, out string error)
+    {
+        options = new GiveOptions();
+        error = string.Empty;
+
+        foreach (var argument in args)
+        {
+            if (uint.TryParse(argument, out var positionalAmount))
+            {
+                options.Amount = positionalAmount;
+                continue;
+            }
+
+            if (!TryParseModifierChain(argument.AsSpan(), options))
+            {
+                error = $"Invalid give modifier '{argument}'.";
+                return false;
+            }
+        }
+
+        if (options.Amount == 0)
+            error = "Count must be at least one.";
+        else if (options.Level is < 1 or > 90)
+            error = "Level must be between 1 and 90.";
+        else if (options.Refinement is < 1 or > 5)
+            error = "Refinement must be between 1 and 5.";
+        else if (options.Constellation > 6)
+            error = "Constellation must be between 0 and 6.";
+
+        return error.Length == 0;
+    }
+
+    /// <summary>Parses standalone or chained modifiers such as <c>lvl90r5x2</c>.</summary>
+    private static bool TryParseModifierChain(ReadOnlySpan<char> input, GiveOptions options)
+    {
+        var offset = 0;
+
+        while (offset < input.Length)
+        {
+            Modifier modifier;
+
+            if (input[offset..].StartsWith("lvl", StringComparison.OrdinalIgnoreCase))
+            {
+                modifier = Modifier.Level;
+                offset += 3;
+            }
+            else if (input[offset..].StartsWith("lv", StringComparison.OrdinalIgnoreCase))
+            {
+                modifier = Modifier.Level;
+                offset += 2;
+            }
+            else
+            {
+                modifier = char.ToLowerInvariant(input[offset]) switch {
+                    'l' => Modifier.Level,
+                    'r' => Modifier.Refinement,
+                    'c' => Modifier.Constellation,
+                    'x' => Modifier.Amount,
+                    _ => Modifier.None
+                };
+                offset++;
+            }
+
+            if (modifier == Modifier.None)
+                return false;
+
+            var numberStart = offset;
+            while (offset < input.Length && char.IsAsciiDigit(input[offset]))
+                offset++;
+
+            if (numberStart == offset || !uint.TryParse(input[numberStart..offset], out var value))
+                return false;
+
+            switch (modifier)
+            {
+                case Modifier.Amount:
+                    options.Amount = value;
+                    break;
+                case Modifier.Level:
+                    options.Level = value;
+                    break;
+                case Modifier.Refinement:
+                    options.Refinement = value;
+                    break;
+                case Modifier.Constellation:
+                    options.Constellation = value;
+                    options.HasConstellation = true;
+                    break;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed class GiveOptions
+    {
+        public uint Amount { get; set; } = 1;
+        public uint Level { get; set; } = 1;
+        public uint Refinement { get; set; } = 1;
+        public uint Constellation { get; set; }
+        public bool HasConstellation { get; set; }
+    }
+
+    private enum Modifier
+    {
+        None,
+        Amount,
+        Level,
+        Refinement,
+        Constellation
+    }
+}

--- a/Source/Starlight/Commands/GiveCommand.cs
+++ b/Source/Starlight/Commands/GiveCommand.cs
@@ -127,6 +127,7 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
         return items.Count;
     }
 
+    // TODO: Remove these hardcoded illegal material IDs once the game data is cleaned up.
     // These resource rows are placeholders, internal-use items, or known to produce invalid
     // inventory entries.
     private static bool IsIllegalMaterial(uint id)

--- a/Source/Starlight/Commands/GiveCommand.cs
+++ b/Source/Starlight/Commands/GiveCommand.cs
@@ -58,6 +58,7 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
                 cancellationToken.ThrowIfCancellationRequested();
                 await GiveWeapons(inventory, options);
                 cancellationToken.ThrowIfCancellationRequested();
+
                 await GiveAvatars(
                     player.Module<AvatarModule>(), options, defaultConstellation: 6);
                 return;
@@ -98,9 +99,9 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
         {
             await inventory.AddWeapons(
                 [weapon],
-                amount: options.Amount,
-                level: options.Level,
-                refinement: options.Refinement);
+                options.Amount,
+                options.Level,
+                options.Refinement);
             return;
         }
 
@@ -130,7 +131,7 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
     // inventory entries.
     private static bool IsIllegalMaterial(uint id)
         => id is 100086 or 100087 or 105001 or 105004 or 107011 or 108000
-            or 220050 or 220054
+               or 220050 or 220054
            || id is >= 100100 and <= 101000
            || id is >= 101106 and <= 101110
            || id is >= 101500 and <= 104000
@@ -145,7 +146,8 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
             .Where(weapon => weapon.Id is >= 11100 and <= 16000)
             .OrderBy(weapon => weapon.Id);
 
-        var amount = Math.Min(options.Amount, 5u);
+        var amount = Math.Min(options.Amount, val2: 5u);
+
         var items = await inventory.AddWeapons(
             resources,
             amount,
@@ -158,7 +160,8 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
     private async Task<int> GiveAvatars(
         AvatarModule avatars,
         GiveOptions options,
-        uint defaultConstellation)
+        uint defaultConstellation
+    )
     {
         var constellation = options.HasConstellation ? options.Constellation : defaultConstellation;
         var count = 0;
@@ -169,6 +172,7 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
                      .Order())
         {
             var (_, added) = await avatars.AddAvatar(avatarId, options.Level, constellation);
+
             if (added)
                 count++;
         }
@@ -231,13 +235,11 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
             {
                 modifier = Modifier.Level;
                 offset += 3;
-            }
-            else if (input[offset..].StartsWith("lv", StringComparison.OrdinalIgnoreCase))
+            } else if (input[offset..].StartsWith("lv", StringComparison.OrdinalIgnoreCase))
             {
                 modifier = Modifier.Level;
                 offset += 2;
-            }
-            else
+            } else
             {
                 modifier = char.ToLowerInvariant(input[offset]) switch {
                     'l' => Modifier.Level,
@@ -253,6 +255,7 @@ public sealed class GiveCommand(PlayerManager players, GameData data) : ICommand
                 return false;
 
             var numberStart = offset;
+
             while (offset < input.Length && char.IsAsciiDigit(input[offset]))
                 offset++;
 

--- a/Source/Starlight/Program.cs
+++ b/Source/Starlight/Program.cs
@@ -21,6 +21,7 @@ using Starlight.Rpc.Tunnel;
 using Starlight.Rpc.Tunnel.Connection;
 using Starlight.SDK;
 using Starlight.SDK.Http.Endpoints;
+using Starlight.Common;
 
 namespace Starlight;
 
@@ -117,6 +118,7 @@ internal static class Program
                 .AddSerilog()
                 .AddCommands()
                 .AddSingleton<GameData>()
+                .AddSingleton<GuidManager>(_ => new GuidManager(serverId: 1))
                 .AddHostedService(s => s.GetRequiredService<GameData>())
                 .AddSingleton<WorldManager>()
                 // Client crypto contains the RSA keys used in dispatch, gate, & on the client.

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Google.Protobuf;
+using Starlight.Common;
 using Starlight.Game.Modules;
 using Starlight.Game.Player;
 using Starlight.Game.Resources;
@@ -113,12 +114,29 @@ public sealed class AvatarEquipTests
             player.State.Avatars.Single(state => state.AvatarId == second.AvatarId).WeaponGuid);
     }
 
+    [Fact]
+    public async Task AddAvatar_ConcurrentCalls_AddOnlyOneAvatar()
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(start: 0, count: 100)
+                .Select(_ => Task.Run(() => avatars.AddAvatar(10000007))));
+
+        Assert.Single(results, result => result.Added);
+        Assert.Single(avatars.Avatars.Values, avatar => avatar.AvatarId == 10000007);
+        Assert.Single(player.State.Avatars, state => state.AvatarId == 10000007);
+    }
+
     private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid, GameData data)
     {
         var services = new ServiceCollection().AddLogging().BuildServiceProvider();
         var registry = new ModuleRegistry();
-        registry.AddModule<InventoryModule>(static (_, player) => new InventoryModule(player));
-        registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data));
+        var guidManager = new GuidManager(serverId: 1);
+        registry.AddModule<InventoryModule>((_, player) => new InventoryModule(player, guidManager, data));
+        registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data, guidManager));
         registry.Build();
 
         var (client, server) = DirectTunnel.CreatePair();

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -21,7 +21,7 @@ public sealed class AvatarEquipTests
     public async Task WearEquip_UpdatesAvatarNotifiesAndPersists()
     {
         var data = Data();
-        var (player, sent) = Player(1001, data);
+        var (player, sent) = Player(uid: 1001, data);
         var avatars = player.Module<AvatarModule>();
         var inventory = player.Module<InventoryModule>();
 
@@ -31,12 +31,13 @@ public sealed class AvatarEquipTests
         sent.Clear();
 
         var avatar = avatars.Avatars[10000005];
+
         var response = await avatars.OnWearEquip(new WearEquipReq {
             AvatarGuid = avatar.Guid,
             EquipGuid = weapon.Guid
         });
 
-        Assert.Equal(0, response.Retcode);
+        Assert.Equal(expected: 0, response.Retcode);
         Assert.Equal(avatar.Guid, response.AvatarGuid);
         Assert.Equal(weapon.Guid, response.EquipGuid);
         Assert.Equal(weapon.Guid, avatar.WeaponGuid);
@@ -45,13 +46,13 @@ public sealed class AvatarEquipTests
         Assert.Equal(avatar.Guid, notify.AvatarGuid);
         Assert.Equal(weapon.Guid, notify.EquipGuid);
         Assert.Equal(weapon.ItemId, notify.ItemId);
-        Assert.Equal(6u, notify.EquipType);
+        Assert.Equal(expected: 6u, notify.EquipType);
 
         var persistedAvatar = Assert.Single(player.State.Avatars);
         Assert.Equal(weapon.Guid, persistedAvatar.WeaponGuid);
 
         var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
-        var (reconnected, _) = Player(1001, data);
+        var (reconnected, _) = Player(uid: 1001, data);
         reconnected.State = persisted;
         await reconnected.Module<AvatarModule>().OnLogin();
 
@@ -64,7 +65,7 @@ public sealed class AvatarEquipTests
     public async Task WearEquip_WeaponOwnedByAnotherAvatar_SwapsWeapons()
     {
         var data = Data();
-        var (player, sent) = Player(1001, data);
+        var (player, sent) = Player(uid: 1001, data);
         var avatars = player.Module<AvatarModule>();
         var inventory = player.Module<InventoryModule>();
 
@@ -83,7 +84,7 @@ public sealed class AvatarEquipTests
             EquipGuid = secondWeapon
         });
 
-        Assert.Equal(0, response.Retcode);
+        Assert.Equal(expected: 0, response.Retcode);
         Assert.Equal(secondWeapon, first.WeaponGuid);
         Assert.Equal(firstWeapon, second.WeaponGuid);
 
@@ -92,7 +93,7 @@ public sealed class AvatarEquipTests
             message => {
                 var unequip = Assert.IsType<AvatarEquipChangeNotify>(message);
                 Assert.Equal(second.Guid, unequip.AvatarGuid);
-                Assert.Equal(0ul, unequip.EquipGuid);
+                Assert.Equal(expected: 0ul, unequip.EquipGuid);
             },
             message => {
                 var equip = Assert.IsType<AvatarEquipChangeNotify>(message);
@@ -107,6 +108,7 @@ public sealed class AvatarEquipTests
 
         Assert.Equal(secondWeapon,
             player.State.Avatars.Single(state => state.AvatarId == first.AvatarId).WeaponGuid);
+
         Assert.Equal(firstWeapon,
             player.State.Avatars.Single(state => state.AvatarId == second.AvatarId).WeaponGuid);
     }
@@ -121,6 +123,7 @@ public sealed class AvatarEquipTests
 
         var (client, server) = DirectTunnel.CreatePair();
         var sent = new List<IMessage>();
+
         _ = client.Subscribe(GameSubjects.OutboundPacket, message => {
             sent.Add(message.Decode<IMessage>());
             return Task.CompletedTask;
@@ -132,19 +135,21 @@ public sealed class AvatarEquipTests
     private static GameData Data()
     {
         var data = new GameData(new ConfigurationBuilder().Build());
+
         data.WeaponData[11501] = new WeaponData {
             Id = 11501,
             GadgetId = 500001,
             SkillAffix = [111]
         };
+
         data.WeaponData[11502] = new WeaponData {
             Id = 11502,
             GadgetId = 500002,
             SkillAffix = [112]
         };
 
-        AddAvatar(data, 10000005, 500, 11501);
-        AddAvatar(data, 10000007, 700, 11502);
+        AddAvatar(data, avatarId: 10000005, depotId: 500, weaponId: 11501);
+        AddAvatar(data, avatarId: 10000007, depotId: 700, weaponId: 11502);
         return data;
     }
 
@@ -160,6 +165,7 @@ public sealed class AvatarEquipTests
             CritChanceBase = 0.05f,
             CritDamageBase = 0.5f
         };
+
         data.AvatarSkillDepotData[depotId] = new AvatarSkillDepotData {
             Id = depotId,
             Skills = [depotId + 1],

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Google.Protobuf;
+using Starlight.Game.Modules;
+using Starlight.Game.Player;
+using Starlight.Game.Resources;
+using Starlight.Game.Resources.Binary;
+using Starlight.Game.Resources.Excel;
+using Starlight.Protocol;
+using Starlight.Rpc;
+using Starlight.Rpc.Proto;
+using Starlight.Rpc.Tunnel;
+using IMessage = Starlight.Protobuf.Core.IMessage;
+using Xunit;
+
+namespace Starlight.Tests;
+
+public sealed class AvatarEquipTests
+{
+    [Fact]
+    public async Task WearEquip_UpdatesAvatarNotifiesAndPersists()
+    {
+        var data = Data();
+        var (player, sent) = Player(1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var inventory = player.Module<InventoryModule>();
+
+        await avatars.OnLogin();
+        await inventory.OnLogin();
+        var weapon = Assert.Single(await inventory.AddWeapons([data.WeaponData[11502]]));
+        sent.Clear();
+
+        var avatar = avatars.Avatars[10000005];
+        var response = await avatars.OnWearEquip(new WearEquipReq {
+            AvatarGuid = avatar.Guid,
+            EquipGuid = weapon.Guid
+        });
+
+        Assert.Equal(0, response.Retcode);
+        Assert.Equal(avatar.Guid, response.AvatarGuid);
+        Assert.Equal(weapon.Guid, response.EquipGuid);
+        Assert.Equal(weapon.Guid, avatar.WeaponGuid);
+
+        var notify = Assert.IsType<AvatarEquipChangeNotify>(Assert.Single(sent));
+        Assert.Equal(avatar.Guid, notify.AvatarGuid);
+        Assert.Equal(weapon.Guid, notify.EquipGuid);
+        Assert.Equal(weapon.ItemId, notify.ItemId);
+        Assert.Equal(6u, notify.EquipType);
+
+        var persistedAvatar = Assert.Single(player.State.Avatars);
+        Assert.Equal(weapon.Guid, persistedAvatar.WeaponGuid);
+
+        var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+        var (reconnected, _) = Player(1001, data);
+        reconnected.State = persisted;
+        await reconnected.Module<AvatarModule>().OnLogin();
+
+        var restored = reconnected.Module<AvatarModule>().Avatars[10000005];
+        Assert.Equal(weapon.Guid, restored.WeaponGuid);
+        Assert.Equal(weapon.ItemId, restored.WeaponItemId);
+    }
+
+    [Fact]
+    public async Task WearEquip_WeaponOwnedByAnotherAvatar_SwapsWeapons()
+    {
+        var data = Data();
+        var (player, sent) = Player(1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var inventory = player.Module<InventoryModule>();
+
+        await avatars.OnLogin();
+        await inventory.OnLogin();
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        sent.Clear();
+
+        var first = avatars.Avatars[10000005];
+        var firstWeapon = first.WeaponGuid;
+        var secondWeapon = second.WeaponGuid;
+
+        var response = await avatars.OnWearEquip(new WearEquipReq {
+            AvatarGuid = first.Guid,
+            EquipGuid = secondWeapon
+        });
+
+        Assert.Equal(0, response.Retcode);
+        Assert.Equal(secondWeapon, first.WeaponGuid);
+        Assert.Equal(firstWeapon, second.WeaponGuid);
+
+        Assert.Collection(
+            sent,
+            message => {
+                var unequip = Assert.IsType<AvatarEquipChangeNotify>(message);
+                Assert.Equal(second.Guid, unequip.AvatarGuid);
+                Assert.Equal(0ul, unequip.EquipGuid);
+            },
+            message => {
+                var equip = Assert.IsType<AvatarEquipChangeNotify>(message);
+                Assert.Equal(second.Guid, equip.AvatarGuid);
+                Assert.Equal(firstWeapon, equip.EquipGuid);
+            },
+            message => {
+                var equip = Assert.IsType<AvatarEquipChangeNotify>(message);
+                Assert.Equal(first.Guid, equip.AvatarGuid);
+                Assert.Equal(secondWeapon, equip.EquipGuid);
+            });
+
+        Assert.Equal(secondWeapon,
+            player.State.Avatars.Single(state => state.AvatarId == first.AvatarId).WeaponGuid);
+        Assert.Equal(firstWeapon,
+            player.State.Avatars.Single(state => state.AvatarId == second.AvatarId).WeaponGuid);
+    }
+
+    private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid, GameData data)
+    {
+        var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var registry = new ModuleRegistry();
+        registry.AddModule<InventoryModule>(static (_, player) => new InventoryModule(player));
+        registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data));
+        registry.Build();
+
+        var (client, server) = DirectTunnel.CreatePair();
+        var sent = new List<IMessage>();
+        _ = client.Subscribe(GameSubjects.OutboundPacket, message => {
+            sent.Add(message.Decode<IMessage>());
+            return Task.CompletedTask;
+        });
+
+        return (new StarlightPlayer(services, registry, server) { Uid = uid }, sent);
+    }
+
+    private static GameData Data()
+    {
+        var data = new GameData(new ConfigurationBuilder().Build());
+        data.WeaponData[11501] = new WeaponData {
+            Id = 11501,
+            GadgetId = 500001,
+            SkillAffix = [111]
+        };
+        data.WeaponData[11502] = new WeaponData {
+            Id = 11502,
+            GadgetId = 500002,
+            SkillAffix = [112]
+        };
+
+        AddAvatar(data, 10000005, 500, 11501);
+        AddAvatar(data, 10000007, 700, 11502);
+        return data;
+    }
+
+    private static void AddAvatar(GameData data, uint avatarId, uint depotId, uint weaponId)
+    {
+        data.AvatarData[avatarId] = new AvatarData {
+            Id = avatarId,
+            InitialWeapon = weaponId,
+            SkillDepotId = depotId,
+            HpBase = 100,
+            AttackBase = 20,
+            DefenseBase = 10,
+            CritChanceBase = 0.05f,
+            CritDamageBase = 0.5f
+        };
+        data.AvatarSkillDepotData[depotId] = new AvatarSkillDepotData {
+            Id = depotId,
+            Skills = [depotId + 1],
+            EnergySkill = depotId + 2
+        };
+        data.Avatars[avatarId] = new AvatarConfig();
+    }
+}

--- a/Tests/Starlight.Tests/GiveCommandTests.cs
+++ b/Tests/Starlight.Tests/GiveCommandTests.cs
@@ -1,0 +1,233 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Google.Protobuf;
+using Starlight.Commands;
+using Starlight.Game.Modules;
+using Starlight.Game.Player;
+using Starlight.Game.Resources;
+using Starlight.Game.Resources.Binary;
+using Starlight.Game.Resources.Excel;
+using Starlight.Protocol;
+using Starlight.Rpc;
+using Starlight.Rpc.Proto;
+using Starlight.Rpc.Tunnel;
+using IMessage = Starlight.Protobuf.Core.IMessage;
+using Xunit;
+
+namespace Starlight.Tests;
+
+public sealed class GiveCommandTests
+{
+    [Fact]
+    public async Task Execute_OnlinePlayer_AddsMaterialAndSendsChange()
+    {
+        var players = new PlayerManager();
+        var (player, sent) = Player(uid: 1001);
+        var inventory = player.Module<InventoryModule>();
+        var data = Data();
+        data.MaterialData[100015] = new MaterialData { Id = 100015 };
+
+        Assert.True(players.Add(player));
+        await inventory.OnLogin();
+        sent.Clear();
+
+        var command = new GiveCommand(players, data);
+        await command.ExecuteAsync(["1001", "100015", "3"], CancellationToken.None);
+
+        Assert.True(inventory.TryGetMaterial(100015, out var material));
+        Assert.Equal(3u, material.Count);
+
+        Assert.Equal(2, sent.Count);
+
+        var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
+        var item = Assert.Single(change.ItemList);
+        Assert.Equal(100015u, item.ItemId);
+        Assert.Equal(3u, item.Material?.Count);
+
+        var hint = Assert.IsType<ItemAddHintNotify>(sent[1]);
+        var added = Assert.Single(hint.ItemList);
+        Assert.Equal(100015u, added.ItemId);
+        Assert.Equal(3u, added.Count);
+    }
+
+    [Fact]
+    public async Task Execute_MissingCount_DefaultsToOne()
+    {
+        var players = new PlayerManager();
+        var (player, _) = Player(uid: 1001);
+        var data = Data();
+        data.MaterialData[100015] = new MaterialData { Id = 100015 };
+        Assert.True(players.Add(player));
+
+        var command = new GiveCommand(players, data);
+        await command.ExecuteAsync(["1001", "100015"], CancellationToken.None);
+
+        var inventory = player.Module<InventoryModule>();
+        Assert.True(inventory.TryGetMaterial(100015, out var material));
+        Assert.Equal(1u, material.Count);
+    }
+
+    [Fact]
+    public async Task Execute_WeaponModifiers_CreateLeveledRefinedCopies()
+    {
+        var players = new PlayerManager();
+        var (player, sent) = Player(uid: 1001);
+        var inventory = player.Module<InventoryModule>();
+        var data = Data();
+        data.WeaponData[11501] = new WeaponData {
+            Id = 11501,
+            SkillAffix = [1234]
+        };
+
+        Assert.True(players.Add(player));
+        await inventory.OnLogin();
+        sent.Clear();
+
+        var command = new GiveCommand(players, data);
+        await command.ExecuteAsync(["1001", "11501", "lvl90r5x2"], CancellationToken.None);
+
+        Assert.Equal(2, inventory.Weapons.Count);
+        Assert.All(inventory.Weapons, weapon => {
+            Assert.Equal(90u, weapon.Level);
+            Assert.Equal(6u, weapon.PromoteLevel);
+            Assert.Equal(5u, weapon.Refinement);
+        });
+
+        var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
+        Assert.Equal(2, change.ItemList.Count);
+        Assert.All(change.ItemList, item => {
+            Assert.Equal(90u, item.Equip?.Weapon?.Level);
+            Assert.Equal(4u, item.Equip?.Weapon?.AffixMap[1234]);
+        });
+    }
+
+    [Fact]
+    public async Task Execute_BulkSelectors_GrantParsedMaterialsAndWeapons()
+    {
+        var players = new PlayerManager();
+        var (player, sent) = Player(uid: 1001);
+        var inventory = player.Module<InventoryModule>();
+        var data = Data();
+        data.MaterialData[100015] = new MaterialData { Id = 100015 };
+        data.MaterialData[100016] = new MaterialData { Id = 100016 };
+        data.MaterialData[100017] = new MaterialData { Id = 100017, ItemType = "ITEM_VIRTUAL" };
+        data.MaterialData[100018] = new MaterialData { Id = 100018, UseOnGain = true };
+        data.MaterialData[100100] = new MaterialData { Id = 100100 };
+        data.WeaponData[11501] = new WeaponData { Id = 11501, SkillAffix = [1234] };
+
+        Assert.True(players.Add(player));
+        await inventory.OnLogin();
+        sent.Clear();
+        var command = new GiveCommand(players, data);
+
+        await command.ExecuteAsync(["1001", "materials", "x7"], CancellationToken.None);
+        await command.ExecuteAsync(["1001", "weapons", "lvl40r3x2"], CancellationToken.None);
+
+        Assert.Equal(2, inventory.Materials.Count);
+        Assert.All(inventory.Materials, material => Assert.Equal(7u, material.Count));
+        Assert.Equal(2, inventory.Weapons.Count);
+        Assert.All(inventory.Weapons, weapon => {
+            Assert.Equal(40u, weapon.Level);
+            Assert.Equal(3u, weapon.Refinement);
+        });
+        Assert.DoesNotContain(sent, message => message is ItemAddHintNotify);
+    }
+
+    [Fact]
+    public async Task Execute_AvatarModifiers_SetLevelConstellationAndStarterWeapon()
+    {
+        var players = new PlayerManager();
+        var data = Data();
+        data.WeaponData[11501] = new WeaponData { Id = 11501, SkillAffix = [1234] };
+        data.AvatarData[10000007] = new AvatarData {
+            Id = 10000007,
+            InitialWeapon = 11501,
+            SkillDepotId = 700,
+            HpBase = 100,
+            AttackBase = 20,
+            DefenseBase = 10,
+            CritChanceBase = 0.05f,
+            CritDamageBase = 0.5f
+        };
+        data.AvatarSkillDepotData[700] = new AvatarSkillDepotData {
+            Id = 700,
+            Skills = [701, 702],
+            EnergySkill = 703,
+            Talents = [710, 711, 712, 713, 714, 715]
+        };
+        data.Avatars[10000007] = new AvatarConfig();
+
+        var (player, sent) = Player(uid: 1001, data);
+        Assert.True(players.Add(player));
+        await player.Module<InventoryModule>().OnLogin();
+        sent.Clear();
+
+        var command = new GiveCommand(players, data);
+        await command.ExecuteAsync(["1001", "10000007", "lvl80c4"], CancellationToken.None);
+
+        var avatar = player.Module<AvatarModule>().Avatars[10000007];
+        Assert.Equal(80u, avatar.Level);
+        Assert.Equal(4u, avatar.Constellation);
+        Assert.Equal(4, avatar.Talents.Count);
+        Assert.Contains(player.Module<InventoryModule>().Weapons,
+            weapon => weapon.Guid == avatar.WeaponGuid);
+
+        Assert.Collection(
+            sent,
+            message => Assert.IsType<StoreItemChangeNotify>(message),
+            message => Assert.IsType<AvatarEquipChangeNotify>(message),
+            message => Assert.IsType<AvatarAddNotify>(message));
+
+        var equip = Assert.IsType<AvatarEquipChangeNotify>(sent[1]);
+        Assert.Equal(avatar.Guid, equip.AvatarGuid);
+        Assert.Equal(avatar.WeaponGuid, equip.EquipGuid);
+        Assert.Equal(6u, equip.EquipType);
+
+        var added = Assert.IsType<AvatarAddNotify>(sent[^1]);
+        Assert.Equal(80, added.Avatar?.PropMap[(uint)PlayerProperty.Level].Val);
+        Assert.Equal(5, added.Avatar?.PropMap[(uint)PlayerProperty.BreakLevel].Val);
+        Assert.Equal(4, added.Avatar?.TalentIdList.Count);
+
+        var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+        var (reconnected, _) = Player(uid: 1001, data);
+        reconnected.State = persisted;
+
+        var (restored, wasAdded) = await reconnected.Module<AvatarModule>()
+            .AddAvatar(10000007);
+
+        Assert.False(wasAdded);
+        Assert.Equal(80u, restored.Level);
+        Assert.Equal(4u, restored.Constellation);
+        await reconnected.Module<InventoryModule>().OnLogin();
+        Assert.True(reconnected.Module<InventoryModule>()
+            .TryGetWeapon(restored.WeaponGuid, out _));
+    }
+
+    private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid, GameData? data = null)
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var registry = new ModuleRegistry();
+        registry.AddModule<InventoryModule>(static (_, player) => new InventoryModule(player));
+
+        if (data is not null)
+            registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data));
+
+        registry.Build();
+
+        var (client, server) = DirectTunnel.CreatePair();
+        var sent = new List<IMessage>();
+
+        _ = client.Subscribe(GameSubjects.OutboundPacket, message => {
+            sent.Add(message.Decode<IMessage>());
+            return Task.CompletedTask;
+        });
+
+        return (new StarlightPlayer(services, registry, server) { Uid = uid }, sent);
+    }
+
+    private static GameData Data()
+        => new(new ConfigurationBuilder().Build());
+}

--- a/Tests/Starlight.Tests/GiveCommandTests.cs
+++ b/Tests/Starlight.Tests/GiveCommandTests.cs
@@ -34,20 +34,20 @@ public sealed class GiveCommandTests
         var command = new GiveCommand(players, data);
         await command.ExecuteAsync(["1001", "100015", "3"], CancellationToken.None);
 
-        Assert.True(inventory.TryGetMaterial(100015, out var material));
-        Assert.Equal(3u, material.Count);
+        Assert.True(inventory.TryGetMaterial(itemId: 100015, out var material));
+        Assert.Equal(expected: 3u, material.Count);
 
-        Assert.Equal(2, sent.Count);
+        Assert.Equal(expected: 2, sent.Count);
 
         var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
         var item = Assert.Single(change.ItemList);
-        Assert.Equal(100015u, item.ItemId);
-        Assert.Equal(3u, item.Material?.Count);
+        Assert.Equal(expected: 100015u, item.ItemId);
+        Assert.Equal(expected: 3u, item.Material?.Count);
 
         var hint = Assert.IsType<ItemAddHintNotify>(sent[1]);
         var added = Assert.Single(hint.ItemList);
-        Assert.Equal(100015u, added.ItemId);
-        Assert.Equal(3u, added.Count);
+        Assert.Equal(expected: 100015u, added.ItemId);
+        Assert.Equal(expected: 3u, added.Count);
     }
 
     [Fact]
@@ -63,8 +63,8 @@ public sealed class GiveCommandTests
         await command.ExecuteAsync(["1001", "100015"], CancellationToken.None);
 
         var inventory = player.Module<InventoryModule>();
-        Assert.True(inventory.TryGetMaterial(100015, out var material));
-        Assert.Equal(1u, material.Count);
+        Assert.True(inventory.TryGetMaterial(itemId: 100015, out var material));
+        Assert.Equal(expected: 1u, material.Count);
     }
 
     [Fact]
@@ -74,6 +74,7 @@ public sealed class GiveCommandTests
         var (player, sent) = Player(uid: 1001);
         var inventory = player.Module<InventoryModule>();
         var data = Data();
+
         data.WeaponData[11501] = new WeaponData {
             Id = 11501,
             SkillAffix = [1234]
@@ -86,18 +87,20 @@ public sealed class GiveCommandTests
         var command = new GiveCommand(players, data);
         await command.ExecuteAsync(["1001", "11501", "lvl90r5x2"], CancellationToken.None);
 
-        Assert.Equal(2, inventory.Weapons.Count);
+        Assert.Equal(expected: 2, inventory.Weapons.Count);
+
         Assert.All(inventory.Weapons, weapon => {
-            Assert.Equal(90u, weapon.Level);
-            Assert.Equal(6u, weapon.PromoteLevel);
-            Assert.Equal(5u, weapon.Refinement);
+            Assert.Equal(expected: 90u, weapon.Level);
+            Assert.Equal(expected: 6u, weapon.PromoteLevel);
+            Assert.Equal(expected: 5u, weapon.Refinement);
         });
 
         var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
-        Assert.Equal(2, change.ItemList.Count);
+        Assert.Equal(expected: 2, change.ItemList.Count);
+
         Assert.All(change.ItemList, item => {
-            Assert.Equal(90u, item.Equip?.Weapon?.Level);
-            Assert.Equal(4u, item.Equip?.Weapon?.AffixMap[1234]);
+            Assert.Equal(expected: 90u, item.Equip?.Weapon?.Level);
+            Assert.Equal(expected: 4u, item.Equip?.Weapon?.AffixMap[1234]);
         });
     }
 
@@ -123,12 +126,13 @@ public sealed class GiveCommandTests
         await command.ExecuteAsync(["1001", "materials", "x7"], CancellationToken.None);
         await command.ExecuteAsync(["1001", "weapons", "lvl40r3x2"], CancellationToken.None);
 
-        Assert.Equal(2, inventory.Materials.Count);
-        Assert.All(inventory.Materials, material => Assert.Equal(7u, material.Count));
-        Assert.Equal(2, inventory.Weapons.Count);
+        Assert.Equal(expected: 2, inventory.Materials.Count);
+        Assert.All(inventory.Materials, material => Assert.Equal(expected: 7u, material.Count));
+        Assert.Equal(expected: 2, inventory.Weapons.Count);
+
         Assert.All(inventory.Weapons, weapon => {
-            Assert.Equal(40u, weapon.Level);
-            Assert.Equal(3u, weapon.Refinement);
+            Assert.Equal(expected: 40u, weapon.Level);
+            Assert.Equal(expected: 3u, weapon.Refinement);
         });
         Assert.DoesNotContain(sent, message => message is ItemAddHintNotify);
     }
@@ -139,6 +143,7 @@ public sealed class GiveCommandTests
         var players = new PlayerManager();
         var data = Data();
         data.WeaponData[11501] = new WeaponData { Id = 11501, SkillAffix = [1234] };
+
         data.AvatarData[10000007] = new AvatarData {
             Id = 10000007,
             InitialWeapon = 11501,
@@ -149,6 +154,7 @@ public sealed class GiveCommandTests
             CritChanceBase = 0.05f,
             CritDamageBase = 0.5f
         };
+
         data.AvatarSkillDepotData[700] = new AvatarSkillDepotData {
             Id = 700,
             Skills = [701, 702],
@@ -166,9 +172,10 @@ public sealed class GiveCommandTests
         await command.ExecuteAsync(["1001", "10000007", "lvl80c4"], CancellationToken.None);
 
         var avatar = player.Module<AvatarModule>().Avatars[10000007];
-        Assert.Equal(80u, avatar.Level);
-        Assert.Equal(4u, avatar.Constellation);
-        Assert.Equal(4, avatar.Talents.Count);
+        Assert.Equal(expected: 80u, avatar.Level);
+        Assert.Equal(expected: 4u, avatar.Constellation);
+        Assert.Equal(expected: 4, avatar.Talents.Count);
+
         Assert.Contains(player.Module<InventoryModule>().Weapons,
             weapon => weapon.Guid == avatar.WeaponGuid);
 
@@ -181,12 +188,12 @@ public sealed class GiveCommandTests
         var equip = Assert.IsType<AvatarEquipChangeNotify>(sent[1]);
         Assert.Equal(avatar.Guid, equip.AvatarGuid);
         Assert.Equal(avatar.WeaponGuid, equip.EquipGuid);
-        Assert.Equal(6u, equip.EquipType);
+        Assert.Equal(expected: 6u, equip.EquipType);
 
         var added = Assert.IsType<AvatarAddNotify>(sent[^1]);
-        Assert.Equal(80, added.Avatar?.PropMap[(uint)PlayerProperty.Level].Val);
-        Assert.Equal(5, added.Avatar?.PropMap[(uint)PlayerProperty.BreakLevel].Val);
-        Assert.Equal(4, added.Avatar?.TalentIdList.Count);
+        Assert.Equal(expected: 80, added.Avatar?.PropMap[(uint)PlayerProperty.Level].Val);
+        Assert.Equal(expected: 5, added.Avatar?.PropMap[(uint)PlayerProperty.BreakLevel].Val);
+        Assert.Equal(expected: 4, added.Avatar?.TalentIdList.Count);
 
         var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
         var (reconnected, _) = Player(uid: 1001, data);
@@ -196,9 +203,10 @@ public sealed class GiveCommandTests
             .AddAvatar(10000007);
 
         Assert.False(wasAdded);
-        Assert.Equal(80u, restored.Level);
-        Assert.Equal(4u, restored.Constellation);
+        Assert.Equal(expected: 80u, restored.Level);
+        Assert.Equal(expected: 4u, restored.Constellation);
         await reconnected.Module<InventoryModule>().OnLogin();
+
         Assert.True(reconnected.Module<InventoryModule>()
             .TryGetWeapon(restored.WeaponGuid, out _));
     }

--- a/Tests/Starlight.Tests/GiveCommandTests.cs
+++ b/Tests/Starlight.Tests/GiveCommandTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Google.Protobuf;
+using Starlight.Common;
 using Starlight.Commands;
 using Starlight.Game.Modules;
 using Starlight.Game.Player;
@@ -22,10 +23,10 @@ public sealed class GiveCommandTests
     public async Task Execute_OnlinePlayer_AddsMaterialAndSendsChange()
     {
         var players = new PlayerManager();
-        var (player, sent) = Player(uid: 1001);
-        var inventory = player.Module<InventoryModule>();
         var data = Data();
-        data.MaterialData[100015] = new MaterialData { Id = 100015 };
+        data.MaterialData[100015] = new MaterialData { Id = 100015, StackLimit = 9999 };
+        var (player, sent) = Player(uid: 1001, data);
+        var inventory = player.Module<InventoryModule>();
 
         Assert.True(players.Add(player));
         await inventory.OnLogin();
@@ -54,9 +55,9 @@ public sealed class GiveCommandTests
     public async Task Execute_MissingCount_DefaultsToOne()
     {
         var players = new PlayerManager();
-        var (player, _) = Player(uid: 1001);
         var data = Data();
-        data.MaterialData[100015] = new MaterialData { Id = 100015 };
+        data.MaterialData[100015] = new MaterialData { Id = 100015, StackLimit = 9999 };
+        var (player, _) = Player(uid: 1001, data);
         Assert.True(players.Add(player));
 
         var command = new GiveCommand(players, data);
@@ -71,9 +72,9 @@ public sealed class GiveCommandTests
     public async Task Execute_WeaponModifiers_CreateLeveledRefinedCopies()
     {
         var players = new PlayerManager();
-        var (player, sent) = Player(uid: 1001);
-        var inventory = player.Module<InventoryModule>();
         var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        var inventory = player.Module<InventoryModule>();
 
         data.WeaponData[11501] = new WeaponData {
             Id = 11501,
@@ -108,15 +109,15 @@ public sealed class GiveCommandTests
     public async Task Execute_BulkSelectors_GrantParsedMaterialsAndWeapons()
     {
         var players = new PlayerManager();
-        var (player, sent) = Player(uid: 1001);
-        var inventory = player.Module<InventoryModule>();
         var data = Data();
-        data.MaterialData[100015] = new MaterialData { Id = 100015 };
-        data.MaterialData[100016] = new MaterialData { Id = 100016 };
+        data.MaterialData[100015] = new MaterialData { Id = 100015, StackLimit = 9999 };
+        data.MaterialData[100016] = new MaterialData { Id = 100016, StackLimit = 9999 };
         data.MaterialData[100017] = new MaterialData { Id = 100017, ItemType = "ITEM_VIRTUAL" };
         data.MaterialData[100018] = new MaterialData { Id = 100018, UseOnGain = true };
-        data.MaterialData[100100] = new MaterialData { Id = 100100 };
+        data.MaterialData[100100] = new MaterialData { Id = 100100, StackLimit = 9999 };
         data.WeaponData[11501] = new WeaponData { Id = 11501, SkillAffix = [1234] };
+        var (player, sent) = Player(uid: 1001, data);
+        var inventory = player.Module<InventoryModule>();
 
         Assert.True(players.Add(player));
         await inventory.OnLogin();
@@ -211,17 +212,18 @@ public sealed class GiveCommandTests
             .TryGetWeapon(restored.WeaponGuid, out _));
     }
 
-    private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid, GameData? data = null)
+    private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid, GameData data)
     {
         var services = new ServiceCollection()
             .AddLogging()
             .BuildServiceProvider();
 
         var registry = new ModuleRegistry();
-        registry.AddModule<InventoryModule>(static (_, player) => new InventoryModule(player));
+        var guidManager = new GuidManager(serverId: 1);
+        registry.AddModule<InventoryModule>((_, player) => new InventoryModule(player, guidManager, data));
 
-        if (data is not null)
-            registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data));
+        if (data.AvatarData.Count > 0)
+            registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data, guidManager));
 
         registry.Build();
 

--- a/Tests/Starlight.Tests/InventoryTests.cs
+++ b/Tests/Starlight.Tests/InventoryTests.cs
@@ -1,7 +1,10 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Google.Protobuf;
+using Starlight.Common;
 using Starlight.Game.Modules;
 using Starlight.Game.Player;
+using Starlight.Game.Resources;
 using Starlight.Game.Resources.Excel;
 using Starlight.Protocol;
 using Starlight.Rpc;
@@ -18,7 +21,7 @@ public sealed class InventoryTests
     public async Task OnLogin_SendsTheSeededInventory()
     {
         var (player, sent) = Player(uid: 1001);
-        var inventory = new InventoryModule(player);
+        var inventory = Inventory(player, Data());
 
         var material = await inventory.AddMaterial(itemId: 100015, count: 3);
         Assert.Empty(sent);
@@ -39,7 +42,7 @@ public sealed class InventoryTests
     public async Task AddMaterial_AfterLogin_SendsAChange()
     {
         var (player, sent) = Player(uid: 1001);
-        var inventory = new InventoryModule(player);
+        var inventory = Inventory(player, Data());
         await inventory.OnLogin();
         sent.Clear();
 
@@ -64,7 +67,7 @@ public sealed class InventoryTests
     public async Task RemoveMaterial_LastItem_SendsADeletion()
     {
         var (player, sent) = Player(uid: 1001);
-        var inventory = new InventoryModule(player);
+        var inventory = Inventory(player, Data());
         var material = await inventory.AddMaterial(itemId: 100015, count: 2);
         await inventory.OnLogin();
         sent.Clear();
@@ -80,7 +83,14 @@ public sealed class InventoryTests
     public async Task AddMaterials_StopsAtAdvertisedMaterialCapacity()
     {
         var (player, sent) = Player(uid: 1001);
-        var inventory = new InventoryModule(player);
+        var data = Data();
+
+        foreach (var itemId in Enumerable.Range(start: 100000, count: 2001))
+        {
+            data.MaterialData[(uint)itemId] = new MaterialData { Id = (uint)itemId, StackLimit = 1 };
+        }
+
+        var inventory = Inventory(player, data);
         await inventory.OnLogin();
         sent.Clear();
 
@@ -99,7 +109,8 @@ public sealed class InventoryTests
     public async Task OnLogin_RestoresInventoryFromPersistedPlayerState()
     {
         var (firstPlayer, _) = Player(uid: 1001);
-        var firstInventory = new InventoryModule(firstPlayer);
+        var data = Data();
+        var firstInventory = Inventory(firstPlayer, data);
 
         await firstInventory.AddMaterial(itemId: 100015, count: 7);
 
@@ -111,7 +122,7 @@ public sealed class InventoryTests
         var persisted = NetPlayerState.Parser.ParseFrom(firstPlayer.State.ToByteArray());
         var (secondPlayer, sent) = Player(uid: 1001);
         secondPlayer.State = persisted;
-        var secondInventory = new InventoryModule(secondPlayer);
+        var secondInventory = Inventory(secondPlayer, data);
 
         await secondInventory.OnLogin();
 
@@ -125,6 +136,75 @@ public sealed class InventoryTests
 
         var store = Assert.IsType<PlayerStoreNotify>(sent[1]);
         Assert.Equal(expected: 2, store.ItemList.Count);
+    }
+
+    [Fact]
+    public async Task AddMaterial_ExistingStack_ClampsToStackLimit()
+    {
+        var (player, sent) = Player(uid: 1001);
+        var data = Data(stackLimit: 10);
+        var inventory = Inventory(player, data);
+
+        await inventory.AddMaterial(itemId: 100015, count: 8);
+        await inventory.OnLogin();
+        sent.Clear();
+
+        var material = await inventory.AddMaterial(itemId: 100015, count: 100);
+
+        Assert.Equal(expected: 10u, material.Count);
+        Assert.Equal(expected: 10u, Assert.Single(player.State.Materials).Count);
+
+        var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
+        Assert.Equal(expected: 10u, Assert.Single(change.ItemList).Material?.Count);
+
+        var hint = Assert.IsType<ItemAddHintNotify>(sent[1]);
+        Assert.Equal(expected: 2u, Assert.Single(hint.ItemList).Count);
+    }
+
+    [Fact]
+    public async Task OnLogin_ClampsPersistedMaterialCountToStackLimit()
+    {
+        var (player, sent) = Player(uid: 1001);
+        var data = Data(stackLimit: 9999);
+
+        player.State.Materials.Add(new NetMaterial {
+            ItemId = 100015,
+            Guid = 123,
+            Count = 99999999
+        });
+
+        var inventory = Inventory(player, data);
+        await inventory.OnLogin();
+
+        Assert.True(inventory.TryGetMaterial(itemId: 100015, out var material));
+        Assert.Equal(expected: 9999u, material.Count);
+        Assert.Equal(expected: 9999u, Assert.Single(player.State.Materials).Count);
+
+        var store = Assert.IsType<PlayerStoreNotify>(sent[1]);
+        Assert.Equal(expected: 9999u, Assert.Single(store.ItemList).Material?.Count);
+    }
+
+    [Fact]
+    public async Task ConcurrentMutations_KeepInventoryAndStateConsistent()
+    {
+        var (player, _) = Player(uid: 1001);
+        var data = Data(stackLimit: 1000);
+        var inventory = Inventory(player, data);
+        var weaponData = new WeaponData { Id = 11501, GadgetId = 500001 };
+
+        var materialTasks = Enumerable.Range(start: 0, count: 200)
+            .Select(_ => Task.Run(() => inventory.AddMaterial(itemId: 100015, count: 1)));
+
+        var weaponTasks = Enumerable.Range(start: 0, count: 200)
+            .Select(_ => Task.Run(() => inventory.AddWeapons([weaponData])));
+
+        await Task.WhenAll(materialTasks.Concat<Task>(weaponTasks));
+
+        Assert.True(inventory.TryGetMaterial(itemId: 100015, out var material));
+        Assert.Equal(expected: 200u, material.Count);
+        Assert.Equal(expected: 200, inventory.Weapons.Count);
+        Assert.Equal(expected: 200u, Assert.Single(player.State.Materials).Count);
+        Assert.Equal(expected: 200, player.State.Weapons.Count);
     }
 
     private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid)
@@ -143,5 +223,15 @@ public sealed class InventoryTests
         });
 
         return (new StarlightPlayer(services, registry, server) { Uid = uid }, sent);
+    }
+
+    private static InventoryModule Inventory(StarlightPlayer player, GameData data)
+        => new(player, new GuidManager(serverId: 1), data);
+
+    private static GameData Data(uint stackLimit = 9999)
+    {
+        var data = new GameData(new ConfigurationBuilder().Build());
+        data.MaterialData[100015] = new MaterialData { Id = 100015, StackLimit = stackLimit };
+        return data;
     }
 }

--- a/Tests/Starlight.Tests/InventoryTests.cs
+++ b/Tests/Starlight.Tests/InventoryTests.cs
@@ -31,8 +31,8 @@ public sealed class InventoryTests
         var store = Assert.IsType<PlayerStoreNotify>(sent[1]);
         var item = Assert.Single(store.ItemList);
         Assert.Equal(material.Guid, item.Guid);
-        Assert.Equal(100015u, item.ItemId);
-        Assert.Equal(3u, item.Material?.Count);
+        Assert.Equal(expected: 100015u, item.ItemId);
+        Assert.Equal(expected: 3u, item.Material?.Count);
     }
 
     [Fact]
@@ -45,19 +45,19 @@ public sealed class InventoryTests
 
         await inventory.AddMaterial(itemId: 100015, count: 2);
 
-        Assert.Equal(2, sent.Count);
+        Assert.Equal(expected: 2, sent.Count);
 
         var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
         var item = Assert.Single(change.ItemList);
-        Assert.Equal(2u, item.Material?.Count);
+        Assert.Equal(expected: 2u, item.Material?.Count);
 
         var hint = Assert.IsType<ItemAddHintNotify>(sent[1]);
         Assert.Equal((uint)ActionReasonType.ACTION_REASON_TYPE_GM, hint.Reason);
         var added = Assert.Single(hint.ItemList);
         Assert.True(added.IsNew);
         Assert.Equal(item.Guid, added.Guid);
-        Assert.Equal(100015u, added.ItemId);
-        Assert.Equal(2u, added.Count);
+        Assert.Equal(expected: 100015u, added.ItemId);
+        Assert.Equal(expected: 2u, added.Count);
     }
 
     [Fact]
@@ -85,13 +85,13 @@ public sealed class InventoryTests
         sent.Clear();
 
         var added = await inventory.AddMaterials(
-            Enumerable.Range(100000, 2001).Select(id => (uint)id),
+            Enumerable.Range(start: 100000, count: 2001).Select(id => (uint)id),
             count: 1,
             showHint: false);
 
-        Assert.Equal(2000, added.Count);
-        Assert.Equal(2000, inventory.Materials.Count);
-        Assert.Equal(20, sent.Count);
+        Assert.Equal(expected: 2000, added.Count);
+        Assert.Equal(expected: 2000, inventory.Materials.Count);
+        Assert.Equal(expected: 20, sent.Count);
         Assert.All(sent, message => Assert.IsType<StoreItemChangeNotify>(message));
     }
 
@@ -102,6 +102,7 @@ public sealed class InventoryTests
         var firstInventory = new InventoryModule(firstPlayer);
 
         await firstInventory.AddMaterial(itemId: 100015, count: 7);
+
         var weapon = await firstInventory.AddWeapons(
             [new WeaponData { Id = 11501, GadgetId = 500001, SkillAffix = [1234] }],
             level: 90,
@@ -114,16 +115,16 @@ public sealed class InventoryTests
 
         await secondInventory.OnLogin();
 
-        Assert.True(secondInventory.TryGetMaterial(100015, out var material));
-        Assert.Equal(7u, material.Count);
+        Assert.True(secondInventory.TryGetMaterial(itemId: 100015, out var material));
+        Assert.Equal(expected: 7u, material.Count);
 
         Assert.True(secondInventory.TryGetWeapon(weapon[0].Guid, out var restoredWeapon));
-        Assert.Equal(90u, restoredWeapon.Level);
-        Assert.Equal(5u, restoredWeapon.Refinement);
-        Assert.Equal(500001u, restoredWeapon.GadgetId);
+        Assert.Equal(expected: 90u, restoredWeapon.Level);
+        Assert.Equal(expected: 5u, restoredWeapon.Refinement);
+        Assert.Equal(expected: 500001u, restoredWeapon.GadgetId);
 
         var store = Assert.IsType<PlayerStoreNotify>(sent[1]);
-        Assert.Equal(2, store.ItemList.Count);
+        Assert.Equal(expected: 2, store.ItemList.Count);
     }
 
     private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid)

--- a/Tests/Starlight.Tests/InventoryTests.cs
+++ b/Tests/Starlight.Tests/InventoryTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.DependencyInjection;
+using Google.Protobuf;
+using Starlight.Game.Modules;
+using Starlight.Game.Player;
+using Starlight.Game.Resources.Excel;
+using Starlight.Protocol;
+using Starlight.Rpc;
+using Starlight.Rpc.Proto;
+using Starlight.Rpc.Tunnel;
+using IMessage = Starlight.Protobuf.Core.IMessage;
+using Xunit;
+
+namespace Starlight.Tests;
+
+public sealed class InventoryTests
+{
+    [Fact]
+    public async Task OnLogin_SendsTheSeededInventory()
+    {
+        var (player, sent) = Player(uid: 1001);
+        var inventory = new InventoryModule(player);
+
+        var material = await inventory.AddMaterial(itemId: 100015, count: 3);
+        Assert.Empty(sent);
+
+        await inventory.OnLogin();
+
+        var limits = Assert.IsType<StoreWeightLimitNotify>(sent[0]);
+        Assert.Equal(StoreType.STORE_TYPE_PACK, limits.StoreType);
+
+        var store = Assert.IsType<PlayerStoreNotify>(sent[1]);
+        var item = Assert.Single(store.ItemList);
+        Assert.Equal(material.Guid, item.Guid);
+        Assert.Equal(100015u, item.ItemId);
+        Assert.Equal(3u, item.Material?.Count);
+    }
+
+    [Fact]
+    public async Task AddMaterial_AfterLogin_SendsAChange()
+    {
+        var (player, sent) = Player(uid: 1001);
+        var inventory = new InventoryModule(player);
+        await inventory.OnLogin();
+        sent.Clear();
+
+        await inventory.AddMaterial(itemId: 100015, count: 2);
+
+        Assert.Equal(2, sent.Count);
+
+        var change = Assert.IsType<StoreItemChangeNotify>(sent[0]);
+        var item = Assert.Single(change.ItemList);
+        Assert.Equal(2u, item.Material?.Count);
+
+        var hint = Assert.IsType<ItemAddHintNotify>(sent[1]);
+        Assert.Equal((uint)ActionReasonType.ACTION_REASON_TYPE_GM, hint.Reason);
+        var added = Assert.Single(hint.ItemList);
+        Assert.True(added.IsNew);
+        Assert.Equal(item.Guid, added.Guid);
+        Assert.Equal(100015u, added.ItemId);
+        Assert.Equal(2u, added.Count);
+    }
+
+    [Fact]
+    public async Task RemoveMaterial_LastItem_SendsADeletion()
+    {
+        var (player, sent) = Player(uid: 1001);
+        var inventory = new InventoryModule(player);
+        var material = await inventory.AddMaterial(itemId: 100015, count: 2);
+        await inventory.OnLogin();
+        sent.Clear();
+
+        Assert.True(await inventory.RemoveMaterial(itemId: 100015, count: 2));
+
+        var deletion = Assert.IsType<StoreItemDelNotify>(Assert.Single(sent));
+        Assert.Equal(material.Guid, Assert.Single(deletion.GuidList));
+        Assert.Empty(inventory.Materials);
+    }
+
+    [Fact]
+    public async Task AddMaterials_StopsAtAdvertisedMaterialCapacity()
+    {
+        var (player, sent) = Player(uid: 1001);
+        var inventory = new InventoryModule(player);
+        await inventory.OnLogin();
+        sent.Clear();
+
+        var added = await inventory.AddMaterials(
+            Enumerable.Range(100000, 2001).Select(id => (uint)id),
+            count: 1,
+            showHint: false);
+
+        Assert.Equal(2000, added.Count);
+        Assert.Equal(2000, inventory.Materials.Count);
+        Assert.Equal(20, sent.Count);
+        Assert.All(sent, message => Assert.IsType<StoreItemChangeNotify>(message));
+    }
+
+    [Fact]
+    public async Task OnLogin_RestoresInventoryFromPersistedPlayerState()
+    {
+        var (firstPlayer, _) = Player(uid: 1001);
+        var firstInventory = new InventoryModule(firstPlayer);
+
+        await firstInventory.AddMaterial(itemId: 100015, count: 7);
+        var weapon = await firstInventory.AddWeapons(
+            [new WeaponData { Id = 11501, GadgetId = 500001, SkillAffix = [1234] }],
+            level: 90,
+            refinement: 5);
+
+        var persisted = NetPlayerState.Parser.ParseFrom(firstPlayer.State.ToByteArray());
+        var (secondPlayer, sent) = Player(uid: 1001);
+        secondPlayer.State = persisted;
+        var secondInventory = new InventoryModule(secondPlayer);
+
+        await secondInventory.OnLogin();
+
+        Assert.True(secondInventory.TryGetMaterial(100015, out var material));
+        Assert.Equal(7u, material.Count);
+
+        Assert.True(secondInventory.TryGetWeapon(weapon[0].Guid, out var restoredWeapon));
+        Assert.Equal(90u, restoredWeapon.Level);
+        Assert.Equal(5u, restoredWeapon.Refinement);
+        Assert.Equal(500001u, restoredWeapon.GadgetId);
+
+        var store = Assert.IsType<PlayerStoreNotify>(sent[1]);
+        Assert.Equal(2, store.ItemList.Count);
+    }
+
+    private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid)
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var registry = new ModuleRegistry().Build();
+        var (client, server) = DirectTunnel.CreatePair();
+        var sent = new List<IMessage>();
+
+        _ = client.Subscribe(GameSubjects.OutboundPacket, message => {
+            sent.Add(message.Decode<IMessage>());
+            return Task.CompletedTask;
+        });
+
+        return (new StarlightPlayer(services, registry, server) { Uid = uid }, sent);
+    }
+}

--- a/Tests/Starlight.Tests/PlayerManagerTests.cs
+++ b/Tests/Starlight.Tests/PlayerManagerTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.DependencyInjection;
+using Starlight.Game.Modules;
+using Starlight.Game.Player;
+using Starlight.Rpc.Tunnel;
+using Xunit;
+
+namespace Starlight.Tests;
+
+public sealed class PlayerManagerTests
+{
+    [Fact]
+    public void Add_IndexesPlayerByUid()
+    {
+        var manager = new PlayerManager();
+        var player = Player(uid: 1001);
+
+        Assert.True(manager.Add(player));
+        Assert.True(manager.TryGet(1001, out var found));
+        Assert.Same(player, found);
+        Assert.Equal(1, manager.Count);
+    }
+
+    [Fact]
+    public void Add_DuplicateUid_LeavesOriginalSessionRegistered()
+    {
+        var manager = new PlayerManager();
+        var original = Player(uid: 1001);
+        var duplicate = Player(uid: 1001);
+
+        Assert.True(manager.Add(original));
+        Assert.False(manager.Add(duplicate));
+        Assert.True(manager.TryGet(1001, out var found));
+        Assert.Same(original, found);
+    }
+
+    [Fact]
+    public void Remove_OldSession_DoesNotRemoveNewSessionWithSameUid()
+    {
+        var manager = new PlayerManager();
+        var oldSession = Player(uid: 1001);
+        var newSession = Player(uid: 1001);
+
+        Assert.True(manager.Add(oldSession));
+        Assert.True(manager.Remove(oldSession));
+        Assert.True(manager.Add(newSession));
+
+        Assert.False(manager.Remove(oldSession));
+        Assert.True(manager.TryGet(1001, out var found));
+        Assert.Same(newSession, found);
+    }
+
+    private static StarlightPlayer Player(uint uid)
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var registry = new ModuleRegistry().Build();
+        var (_, tunnel) = DirectTunnel.CreatePair();
+
+        return new StarlightPlayer(services, registry, tunnel) { Uid = uid };
+    }
+}

--- a/Tests/Starlight.Tests/PlayerManagerTests.cs
+++ b/Tests/Starlight.Tests/PlayerManagerTests.cs
@@ -15,9 +15,9 @@ public sealed class PlayerManagerTests
         var player = Player(uid: 1001);
 
         Assert.True(manager.Add(player));
-        Assert.True(manager.TryGet(1001, out var found));
+        Assert.True(manager.TryGet(uid: 1001, out var found));
         Assert.Same(player, found);
-        Assert.Equal(1, manager.Count);
+        Assert.Equal(expected: 1, manager.Count);
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public sealed class PlayerManagerTests
 
         Assert.True(manager.Add(original));
         Assert.False(manager.Add(duplicate));
-        Assert.True(manager.TryGet(1001, out var found));
+        Assert.True(manager.TryGet(uid: 1001, out var found));
         Assert.Same(original, found);
     }
 
@@ -45,7 +45,7 @@ public sealed class PlayerManagerTests
         Assert.True(manager.Add(newSession));
 
         Assert.False(manager.Remove(oldSession));
-        Assert.True(manager.TryGet(1001, out var found));
+        Assert.True(manager.TryGet(uid: 1001, out var found));
         Assert.Same(newSession, found);
     }
 

--- a/Tests/Starlight.Tests/World/WorldTests.cs
+++ b/Tests/Starlight.Tests/World/WorldTests.cs
@@ -18,6 +18,7 @@ file static class Session
     public static IServiceProvider Services() => new ServiceCollection()
         .AddLogging()
         .AddSingleton<RpcTransport, DirectRpcTransport>()
+        .AddSingleton<PlayerManager>()
         .AddSingleton<WorldManager>()
         .BuildServiceProvider();
 


### PR DESCRIPTION
<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->

## Summary
Adds an initial player manager system, including persistent inventories, avatars, weapons and a `/give` command for testing.
Improves KCP handling for large S2C updates by adding outbound backpressure and a small deadlink recovery period

## Type of Change
- [x] Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Performance Improvement
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Added PlayerManager for tracking online players and rejecting duplicate sessions
- Added player inventory support for materials and weapons
- Added avatar ownership, start weapons, and avatar inventory sync
- Added weapon equipment through WearEquipReq, WearEquipRsp, and AvatarEquipChangeNotify
- Added weapon swapping when the requested weapon is equipped by another avatar
- Added /give support for individual items, materials, weapons, avatars, and all
- Added /give modifiers for count, level, refinement, and constellation
- Added persistent player state through DbGate
- Added an SQLite schema upgrade for existing databases
- Added batched inventory notifications and KCP send backpressure
- Added KCP deadlink recovery handling for delayed acks
- Improved disconnect debugging with reason codes and pending segment counts
- Added player manager, inventory, give command, persistence, and weapon equip tests

## Implementation Details
Player inventory and avatar data is stored in the database and loaded when the player logs in. Changes are saved when the player disconnects.

Large inventory updates are split into smaller batches to avoid overwhelming the client (please stop disconnecting...).
KCP now waits when too many packets are pending. It also gives delayed packets a short chance to recover before disconnecting the client.
Equipping a weapon updates the avatar and notifies the client. If another avatar is already using that weapon, their weapons are swapped.

## Testing
- [x] Unit tests added/updated
- [ ] Existing tests pass
- [x] Manually tested

Describe how this was tested.

## Performance Impact
- [ ] No impact
- [x] Minor impact
- [ ] Significant impact (explain below)

## Breaking Changes
- [x] No
- [ ] Yes (describe below)

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] CI passes
- [x] No unnecessary changes included
- [x] Documentation updated (if needed)

## Additional Notes
Player state saves when the session closes rather than when an action occurs. This may lead to loss of changes, if the server closes abruptly

<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->