### PR TITLE
feat: player born and initial cutscene

### DIFF
--- a/Game/Starlight.Game.Player/AvatarModule.cs
+++ b/Game/Starlight.Game.Player/AvatarModule.cs
@@ -87,7 +87,7 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
         {
             return new AvatarDataNotify {
                 CurAvatarTeamId = TeamId,
-                ChooseAvatarGuid = _team[0].Guid,
+                ChooseAvatarGuid = _team.FirstOrDefault()?.Guid ?? 0,
                 OwnedFlycloakList = [Avatar.DefaultFlycloak],
                 AvatarList = [.. _avatars.Values.Select(avatar => avatar.Info())],
                 AvatarTeamMap = {
@@ -172,7 +172,8 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
     public async Task<(Avatar? Avatar, bool Added)> AddAvatar(
         uint avatarId,
         uint level = 1,
-        uint constellation = 0
+        uint constellation = 0,
+        bool isInTeam = false
     )
     {
         Avatar avatar;
@@ -229,7 +230,7 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
 
         await player.Send(new AvatarAddNotify {
             Avatar = avatarInfo,
-            IsInTeam = false
+            IsInTeam = isInTeam
         });
 
         return (avatar, true);
@@ -267,31 +268,37 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
                 _avatarState.Add(avatar.AvatarId, state);
             }
 
-            // A brand-new player receives the starter roster once. It immediately becomes part of
-            // the persisted state, so reconnects preserve its GUID and born time.
-            foreach (var (slot, avatarId) in TeamAvatarIds.Index())
+            var initialTeamAvatarIds =
+                player.State.BornAvatarId is AetherId or LumineId ? [player.State.BornAvatarId] : TeamAvatarIds;
+
+            if (player.State.BornState != NetPlayerState.Types.PlayerBornState.Pending)
             {
-                if (_avatars.ContainsKey(avatarId) || !CanCreate(avatarId))
-                    continue;
+                // A brand-new player receives the starter roster once. It immediately becomes part of
+                // the persisted state, so reconnects preserve its GUID and born time.
+                foreach (var (slot, avatarId) in initialTeamAvatarIds.Index())
+                {
+                    if (_avatars.ContainsKey(avatarId) || !CanCreate(avatarId))
+                        continue;
 
-                var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
-                var avatar = Avatar.Create(data, avatarId, guid);
+                    var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
+                    var avatar = Avatar.Create(data, avatarId, guid);
 
-                var state = new NetAvatar {
-                    AvatarId = avatar.AvatarId,
-                    Guid = avatar.Guid,
-                    Level = avatar.Level,
-                    Constellation = avatar.Constellation,
-                    BornTime = avatar.BornTime,
-                    WeaponGuid = avatar.WeaponGuid
-                };
+                    var state = new NetAvatar {
+                        AvatarId = avatar.AvatarId,
+                        Guid = avatar.Guid,
+                        Level = avatar.Level,
+                        Constellation = avatar.Constellation,
+                        BornTime = avatar.BornTime,
+                        WeaponGuid = avatar.WeaponGuid
+                    };
 
-                _avatars.Add(avatarId, avatar);
-                _avatarState.Add(avatarId, state);
-                player.State.Avatars.Add(state);
+                    _avatars.Add(avatarId, avatar);
+                    _avatarState.Add(avatarId, state);
+                    player.State.Avatars.Add(state);
+                }
             }
 
-            _team = TeamAvatarIds
+            _team = initialTeamAvatarIds
                 .Where(_avatars.ContainsKey)
                 .Select(id => _avatars[id])
                 .ToArray();
@@ -305,6 +312,56 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
             avatar.EquipWeapon(weapon);
             _avatarState[avatar.AvatarId].WeaponGuid = weapon.Guid;
         }
+    }
+
+    private const uint AetherId = 10000005;
+    private const uint LumineId = 10000007;
+
+    public async Task<Avatar?> InitializeTraveler(uint avatarId)
+    {
+        // Prevent players from getting a different avatar via modifying packets.
+        if (avatarId is not AetherId and not LumineId)
+            return null;
+
+        lock (player.StateLock)
+        {
+            LoadState();
+
+            if (player.State.BornState !=
+                NetPlayerState.Types.PlayerBornState.Pending)
+            {
+                return null;
+            }
+        }
+
+        var (avatar, _) = await AddAvatar(avatarId, level: 1, constellation: 0, isInTeam: true);
+
+        if (avatar is null)
+            return null;
+
+        AvatarTeamUpdateNotify notify;
+
+        lock (player.StateLock)
+        {
+            _team = [avatar];
+
+            player.State.BornAvatarId = avatarId;
+
+            player.State.BornState =
+                NetPlayerState.Types.PlayerBornState.Complete;
+
+            notify = new AvatarTeamUpdateNotify {
+                AvatarTeamMap = {
+                    [TeamId] = new AvatarTeam {
+                        TeamName = $"Team {TeamId}",
+                        AvatarGuidList = { avatar.Guid }
+                    }
+                }
+            };
+        }
+
+        await player.Send(notify);
+        return avatar;
     }
 
     private static AvatarEquipChangeNotify CreateWeaponChangeNotify(Avatar avatar, WeaponItem weapon)

--- a/Game/Starlight.Game.Player/BornModule.cs
+++ b/Game/Starlight.Game.Player/BornModule.cs
@@ -6,10 +6,26 @@ namespace Starlight.Game.Player;
 
 public sealed class BornModule(IPlayer player) : IModule
 {
+    private readonly SemaphoreSlim _gate = new(initialCount: 1, maxCount: 1);
+
     [Opcode]
     public async Task OnSetPlayerBornData(
         SetPlayerBornDataReq message
     )
+    {
+        await _gate.WaitAsync();
+
+        try
+        {
+            await SetPlayerBornData(message);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task SetPlayerBornData(SetPlayerBornDataReq message)
     {
         bool alreadyBorn;
 

--- a/Game/Starlight.Game.Player/BornModule.cs
+++ b/Game/Starlight.Game.Player/BornModule.cs
@@ -1,0 +1,79 @@
+using Starlight.Game.Modules;
+using Starlight.Protocol;
+using Starlight.Rpc.Proto;
+
+namespace Starlight.Game.Player;
+
+public sealed class BornModule(IPlayer player) : IModule
+{
+    [Opcode]
+    public async Task OnSetPlayerBornData(
+        SetPlayerBornDataReq message
+    )
+    {
+        bool alreadyBorn;
+
+        lock (player.StateLock)
+        {
+            alreadyBorn = player.State.BornState !=
+                          NetPlayerState.Types.PlayerBornState.Pending;
+        }
+
+        if (alreadyBorn)
+        {
+            await player.Send(new SetPlayerBornDataRsp {
+                Retcode = (int)Retcode.RETCODE_REPEAT_SET_PLAYER_BORN_DATA
+            });
+            return;
+        }
+
+        if (message.AvatarId is not 10000005 and not 10000007)
+        {
+            await player.Send(new SetPlayerBornDataRsp {
+                Retcode = (int)Retcode.RETCODE_AVATAR_ID_ERROR
+            });
+            return;
+        }
+
+        var nickname = message.NickName.Trim();
+
+        if (nickname.Length == 0)
+        {
+            await player.Send(new SetPlayerBornDataRsp {
+                Retcode = (int)Retcode.RETCODE_NICKNAME_IS_EMPTY
+            });
+            return;
+        }
+
+        if (nickname.Length > 16)
+        {
+            await player.Send(new SetPlayerBornDataRsp {
+                Retcode = (int)Retcode.RETCODE_NICKNAME_TOO_LONG
+            });
+            return;
+        }
+
+        var avatar = await player.Module<AvatarModule>()
+            .InitializeTraveler(message.AvatarId);
+
+        if (avatar is null)
+        {
+            await player.Send(new SetPlayerBornDataRsp {
+                Retcode = (int)Retcode.RETCODE_AVATAR_ID_ERROR
+            });
+            return;
+        }
+
+        lock (player.StateLock)
+        {
+            player.Profile.Nickname = nickname;
+        }
+
+        await player.Send(new SetPlayerBornDataRsp());
+
+        await player.Send(new PlayerNicknameNotify {
+            Nickname = nickname
+        });
+        await player.Emit(LifecycleEvent.PlayerBorn);
+    }
+}

--- a/Game/Starlight.Game.World/SceneModule.cs
+++ b/Game/Starlight.Game.World/SceneModule.cs
@@ -2,6 +2,7 @@ using Starlight.Game.Modules;
 using Starlight.Game.Player;
 using Starlight.Protobuf.Core;
 using Starlight.Protocol;
+using Starlight.Rpc.Proto;
 
 namespace Starlight.Game.World;
 
@@ -20,11 +21,15 @@ public sealed class SceneModule(IPlayer player) : IModule
     #endregion
 
     [Lifecycle(LifecycleEvent.PlayerLogin)]
-    public PlayerEnterSceneNotify OnLogin() => new() {
-        Type = EnterType.ENTER_TYPE_ENTER_SELF,
-        SceneId = SpawnSceneId,
-        Pos = SpawnPosition
-    };
+    public PlayerEnterSceneNotify? OnLogin()
+        => player.State.BornState == NetPlayerState.Types.PlayerBornState.Pending ? null : EnterScene();
+
+    [Lifecycle(LifecycleEvent.PlayerBorn)]
+    public PlayerEnterSceneNotify OnBorn()
+    {
+        player.Module<WorldModule>().EnterOwnWorld();
+        return EnterScene();
+    }
 
     [Opcode]
     public IEnumerable<IMessage> OnEnterSceneReady(EnterSceneReadyReq msg)
@@ -130,4 +135,10 @@ public sealed class SceneModule(IPlayer player) : IModule
     public PostEnterSceneRsp OnPostEnterScene(PostEnterSceneReq msg) =>
         // TODO: Validate `enter_scene_token`.
         new() { EnterSceneToken = msg.EnterSceneToken };
+
+    private static PlayerEnterSceneNotify EnterScene() => new() {
+        Type = EnterType.ENTER_TYPE_ENTER_SELF,
+        SceneId = SpawnSceneId,
+        Pos = SpawnPosition
+    };
 }

--- a/Game/Starlight.Game.World/WorldModule.cs
+++ b/Game/Starlight.Game.World/WorldModule.cs
@@ -1,6 +1,7 @@
 using Starlight.Game.Modules;
 using Starlight.Game.Player;
 using Starlight.Protocol;
+using Starlight.Rpc.Proto;
 
 namespace Starlight.Game.World;
 
@@ -23,7 +24,11 @@ public sealed class WorldModule(IPlayer player, WorldManager worlds) : IModule
     public Scene? Scene { get; internal set; }
 
     [Lifecycle(LifecycleEvent.PlayerLogin)]
-    public void OnLogin() => EnterOwnWorld();
+    public void OnLogin()
+    {
+        if (player.State.BornState != NetPlayerState.Types.PlayerBornState.Pending)
+            EnterOwnWorld();
+    }
 
     /// <summary>Puts this player into their own world. Call once login has assigned their uid.</summary>
     public void EnterOwnWorld() => Enter(worlds.Open(player));

--- a/Libraries/Starlight.Protocol/Lifecycle.cs
+++ b/Libraries/Starlight.Protocol/Lifecycle.cs
@@ -18,13 +18,13 @@ public sealed class LifecycleAttribute(LifecycleEvent @event, LifecycleOrder ord
 public enum LifecycleEvent
 {
     /// Sent once <c>PlayerLoginReq</c> has loaded the player's data, before <c>PlayerLoginRsp</c> goes out.
-    PlayerLogin,
-    /// Sent after a new player has selected their Traveler and nickname.
-    PlayerBorn,
+    PlayerLogin = 0,
     /// Sent when the KCP session is dropped. The tunnel is gone by now, so sends are discarded.
-    PlayerDisconnect,
+    PlayerDisconnect = 1,
     /// Sent when the player data is being saved to the database, before a PlayerDisconnect.
-    PlayerSaving
+    PlayerSaving = 2,
+    /// Sent after a new player has selected their Traveler and nickname.
+    PlayerBorn = 3
 }
 
 public enum LifecycleOrder

--- a/Libraries/Starlight.Protocol/Lifecycle.cs
+++ b/Libraries/Starlight.Protocol/Lifecycle.cs
@@ -19,6 +19,8 @@ public enum LifecycleEvent
 {
     /// Sent once <c>PlayerLoginReq</c> has loaded the player's data, before <c>PlayerLoginRsp</c> goes out.
     PlayerLogin,
+    /// Sent after a new player has selected their Traveler and nickname.
+    PlayerBorn,
     /// Sent when the KCP session is dropped. The tunnel is gone by now, so sends are discarded.
     PlayerDisconnect,
     /// Sent when the player data is being saved to the database, before a PlayerDisconnect.

--- a/Libraries/Starlight.Rpc/Protobuf/starlight.player.proto
+++ b/Libraries/Starlight.Rpc/Protobuf/starlight.player.proto
@@ -1,4 +1,4 @@
-﻿syntax = "proto3";
+syntax = "proto3";
 
 package starlight.player;
 
@@ -23,9 +23,19 @@ message NetPlayerProfile {
 }
 
 message NetPlayerState {
+  enum PlayerBornState {
+    PLAYER_BORN_STATE_UNSPECIFIED = 0;
+    PLAYER_BORN_STATE_PENDING = 1;
+    PLAYER_BORN_STATE_COMPLETE = 2;
+    PLAYER_BORN_STATE_AUTOMATIC = 3;
+  }
+
   repeated NetMaterial materials = 1;
   repeated NetWeapon weapons = 2;
   repeated NetAvatar avatars = 3;
+
+  PlayerBornState born_state = 4;
+  uint32 born_avatar_id = 5;
 }
 
 message NetMaterial {
@@ -83,6 +93,7 @@ message FetchPlayerRsp {
 message SavePlayerReq {
   uint32 uid = 1;
   NetPlayerState state = 2;
+  NetPlayerProfile profile = 3;
 }
 
 // Path: DB Gate -> Game Server

--- a/Source/Starlight.DbGate/Services/PlayerService.cs
+++ b/Source/Starlight.DbGate/Services/PlayerService.cs
@@ -91,7 +91,9 @@ public sealed class PlayerService(IServiceScopeFactory scopes, ILogger<PlayerSer
         using var scope = scopes.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<StarlightDbContext>();
 
-        var player = await db.Players.FirstOrDefaultAsync(player => player.Id == msg.Uid);
+        var player = await db.Players
+            .Include(player => player.Profile)
+            .FirstOrDefaultAsync(player => player.Id == msg.Uid);
 
         if (player is null)
         {
@@ -102,6 +104,15 @@ public sealed class PlayerService(IServiceScopeFactory scopes, ILogger<PlayerSer
         try
         {
             player.State = (msg.State ?? new NetPlayerState()).ToByteArray();
+
+            if (msg.Profile is {} profile)
+            {
+                player.Profile.Nickname = profile.Nickname;
+                player.Profile.Signature = profile.Signature;
+                player.Profile.PictureId = profile.PictureId;
+                player.Profile.NameCardId = profile.NameCardId;
+            }
+
             await db.SaveChangesAsync();
             await rpc.Reply(new SavePlayerRsp { Retcode = StarlightRetcode.Success });
         }

--- a/Source/Starlight.DbGate/StarlightDbContext.cs
+++ b/Source/Starlight.DbGate/StarlightDbContext.cs
@@ -49,7 +49,10 @@ public sealed class StarlightDbContext(DbContextOptions options) : DbContext(opt
 /// Preserves early-development databases when player state is introduced. The generic schema
 /// checker intentionally archives drifted files, but this change is safely additive.
 /// </summary>
-internal sealed class PlayerStateSchemaUpgradeService(IServiceScopeFactory scopes, ILogger logger) : IHostedService
+internal sealed class PlayerStateSchemaUpgradeService(
+    IServiceScopeFactory scopes,
+    ILogger<PlayerStateSchemaUpgradeService> logger
+) : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {

--- a/Source/Starlight.Game/Player/IPlayer.cs
+++ b/Source/Starlight.Game/Player/IPlayer.cs
@@ -19,6 +19,9 @@ public interface IPlayer
     /// <summary>Game-owned state loaded from and saved through DbGate.</summary>
     NetPlayerState State { get; internal set; }
 
+    /// <summary>Player profile loaded from and saved through DbGate.</summary>
+    NetPlayerProfile Profile { get; internal set; }
+
     /// <summary>Synchronizes access to this player's live module and persisted state.</summary>
     object StateLock { get; }
 

--- a/Source/Starlight.Game/Player/PlayerModule.cs
+++ b/Source/Starlight.Game/Player/PlayerModule.cs
@@ -28,6 +28,7 @@ public sealed class PlayerModule(
     public async Task<PlayerLoginRsp> OnLogin(PlayerLoginReq msg)
     {
         string nickname;
+        bool isNewPlayer;
 
         try
         {
@@ -49,8 +50,20 @@ public sealed class PlayerModule(
             lock (player.StateLock)
             {
                 player.State = data.State ?? new NetPlayerState();
+                player.Profile = data.Profile ?? new NetPlayerProfile();
+
+                if (player.State.BornState == NetPlayerState.Types.PlayerBornState.Unspecified)
+                {
+                    player.State.BornState = player.State.Avatars.Count > 0 ?
+                        NetPlayerState.Types.PlayerBornState.Complete :
+                        NetPlayerState.Types.PlayerBornState.Pending;
+                }
+
+                isNewPlayer =
+                    player.State.BornState == NetPlayerState.Types.PlayerBornState.Pending;
+
+                nickname = player.Profile.Nickname;
             }
-            nickname = data.Profile?.Nickname ?? string.Empty;
 
             if (!players.Add(player))
             {
@@ -88,11 +101,15 @@ public sealed class PlayerModule(
         // Everything that has to be in place before the client is told it is logged in.
         await player.Emit(LifecycleEvent.PlayerLogin);
 
+        if (isNewPlayer)
+            await player.Send(new DoSetPlayerBornDataNotify());
+
         return new PlayerLoginRsp {
             IsUseAbilityHash = true,
             AbilityHashCode = 1844674,
             GameBiz = "hk4e_global",
-            CountryCode = "US"
+            CountryCode = "US",
+            IsNewPlayer = isNewPlayer
         };
     }
 
@@ -109,17 +126,20 @@ public sealed class PlayerModule(
         try
         {
             NetPlayerState state;
+            NetPlayerProfile profile;
 
             lock (player.StateLock)
             {
                 state = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+                profile = NetPlayerProfile.Parser.ParseFrom(player.Profile.ToByteArray());
             }
 
             var response = await rpc.Request<SavePlayerReq, SavePlayerRsp>(
                 GameSubjects.SavePlayer,
                 new SavePlayerReq {
                     Uid = player.Uid,
-                    State = state
+                    State = state,
+                    Profile = profile
                 });
 
             if (response.Retcode != StarlightRetcode.Success)

--- a/Source/Starlight.Game/Player/StarlightPlayer.cs
+++ b/Source/Starlight.Game/Player/StarlightPlayer.cs
@@ -29,6 +29,7 @@ public sealed class StarlightPlayer : IPlayer
     public string AccountUid { get; set; } = string.Empty;
     public CancellationToken Closing => _tunnel.Closed;
     public NetPlayerState State { get; set; } = new();
+    public NetPlayerProfile Profile { get; set; } = new();
     public object StateLock { get; } = new();
 
     /// <inheritdoc/>

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -19,6 +19,57 @@ namespace Starlight.Tests;
 public sealed class AvatarEquipTests
 {
     [Fact]
+    public async Task SetPlayerBornData_PersistsNicknameAndSelectedTraveler()
+    {
+        var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        player.State.BornState = NetPlayerState.Types.PlayerBornState.Pending;
+
+        await player.Module<BornModule>().OnSetPlayerBornData(
+            new SetPlayerBornDataReq {
+                AvatarId = 10000007,
+                NickName = "Lumine"
+            });
+
+        var response = Assert.Single(sent.OfType<SetPlayerBornDataRsp>());
+        Assert.Equal(expected: 0, response.Retcode);
+        Assert.Equal("Lumine", player.Profile.Nickname);
+        Assert.Equal(expected: 10000007u, player.State.BornAvatarId);
+
+        Assert.Equal(
+            NetPlayerState.Types.PlayerBornState.Complete,
+            player.State.BornState);
+
+        var traveler = Assert.Single(player.Module<AvatarModule>().Team);
+        Assert.Equal(expected: 10000007u, traveler.AvatarId);
+        Assert.Single(player.State.Avatars, state => state.AvatarId == 10000007);
+
+        var nicknameNotify = Assert.Single(sent.OfType<PlayerNicknameNotify>());
+        Assert.Equal("Lumine", nicknameNotify.Nickname);
+
+        var snapshot = new SavePlayerReq {
+            Uid = player.Uid,
+            State = player.State,
+            Profile = player.Profile
+        };
+        var restored = SavePlayerReq.Parser.ParseFrom(snapshot.ToByteArray());
+
+        Assert.Equal("Lumine", restored.Profile?.Nickname);
+        Assert.Equal(expected: 10000007u, restored.State?.BornAvatarId);
+
+        var (reconnected, _) = Player(uid: 1001, data);
+        reconnected.State = restored.State ?? new NetPlayerState();
+        reconnected.Profile = restored.Profile ?? new NetPlayerProfile();
+        await reconnected.Module<AvatarModule>().OnLogin();
+
+        Assert.Equal("Lumine", reconnected.Profile.Nickname);
+
+        Assert.Equal(
+            expected: 10000007u,
+            Assert.Single(reconnected.Module<AvatarModule>().Team).AvatarId);
+    }
+
+    [Fact]
     public async Task WearEquip_UpdatesAvatarNotifiesAndPersists()
     {
         var data = Data();
@@ -137,6 +188,7 @@ public sealed class AvatarEquipTests
         var guidManager = new GuidManager(serverId: 1);
         registry.AddModule<InventoryModule>((_, player) => new InventoryModule(player, guidManager, data));
         registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data, guidManager));
+        registry.AddModule<BornModule>((_, player) => new BornModule(player));
         registry.Build();
 
         var (client, server) = DirectTunnel.CreatePair();

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -19,6 +19,40 @@ namespace Starlight.Tests;
 public sealed class AvatarEquipTests
 {
     [Fact]
+    public async Task SetPlayerBornData_ConcurrentRequests_OnlyInitializeOneTraveler()
+    {
+        var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        player.State.BornState = NetPlayerState.Types.PlayerBornState.Pending;
+        var born = player.Module<BornModule>();
+
+        await Task.WhenAll(
+            born.OnSetPlayerBornData(new SetPlayerBornDataReq {
+                AvatarId = 10000005,
+                NickName = "Aether"
+            }),
+            born.OnSetPlayerBornData(new SetPlayerBornDataReq {
+                AvatarId = 10000007,
+                NickName = "Lumine"
+            }));
+
+        var responses = sent.OfType<SetPlayerBornDataRsp>().ToArray();
+        Assert.Equal(expected: 2, responses.Length);
+        Assert.Single(responses, response => response.Retcode == 0);
+
+        Assert.Single(
+            responses,
+            response => response.Retcode == (int)Retcode.RETCODE_REPEAT_SET_PLAYER_BORN_DATA);
+
+        var traveler = Assert.Single(player.State.Avatars);
+        Assert.Equal(traveler.AvatarId, player.State.BornAvatarId);
+
+        Assert.Equal(
+            traveler.AvatarId == 10000005 ? "Aether" : "Lumine",
+            player.Profile.Nickname);
+    }
+
+    [Fact]
     public async Task SetPlayerBornData_PersistsNicknameAndSelectedTraveler()
     {
         var data = Data();

--- a/Tests/Starlight.Tests/PlayerManagerTests.cs
+++ b/Tests/Starlight.Tests/PlayerManagerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Starlight.Game.Modules;
 using Starlight.Game.Player;
+using Starlight.Protocol;
 using Starlight.Rpc.Tunnel;
 using Xunit;
 
@@ -8,6 +9,15 @@ namespace Starlight.Tests;
 
 public sealed class PlayerManagerTests
 {
+    [Fact]
+    public void LifecycleEvent_ExistingValuesRemainStable()
+    {
+        Assert.Equal(expected: 0, (int)LifecycleEvent.PlayerLogin);
+        Assert.Equal(expected: 1, (int)LifecycleEvent.PlayerDisconnect);
+        Assert.Equal(expected: 2, (int)LifecycleEvent.PlayerSaving);
+        Assert.Equal(expected: 3, (int)LifecycleEvent.PlayerBorn);
+    }
+
     [Fact]
     public void Add_IndexesPlayerByUid()
     {

--- a/Tests/Starlight.Tests/World/WorldTests.cs
+++ b/Tests/Starlight.Tests/World/WorldTests.cs
@@ -5,6 +5,7 @@ using Starlight.Game.Player;
 using Starlight.Game.World;
 using Starlight.Protocol;
 using Starlight.Rpc;
+using Starlight.Rpc.Proto;
 using Starlight.Rpc.Tunnel;
 using Xunit;
 
@@ -38,6 +39,26 @@ file static class Session
 
 public sealed class WorldPeerTests
 {
+    [Fact]
+    public void PendingPlayer_WaitsForBornSelectionBeforeEnteringWorld()
+    {
+        var services = Session.Services();
+        var registry = Session.Registry();
+        var player = Session.Player(services, registry, uid: 1001);
+        player.State.BornState = NetPlayerState.Types.PlayerBornState.Pending;
+
+        player.Module<WorldModule>().OnLogin();
+        var loginScene = player.Module<SceneModule>().OnLogin();
+
+        Assert.Equal(expected: 0u, player.Module<WorldModule>().PeerId);
+        Assert.Null(loginScene);
+
+        var bornScene = player.Module<SceneModule>().OnBorn();
+
+        Assert.Equal(expected: 1u, player.Module<WorldModule>().PeerId);
+        Assert.Equal(expected: 3u, bornScene.SceneId);
+    }
+
     [Fact]
     public void EnterOwnWorld_Owner_TakesHostPeerId()
     {


### PR DESCRIPTION
<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->

## Summary
Implemented the initial cutscene and a fallback for when the packets aren't available

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Added logic around player born data
- Modified login logic to fit the new features in

## Testing
- [x] Unit tests added/updated
- [x] Existing tests pass
- [x] Manually tested

Tested an existing account that was created before the feature was added, then another account after the feature was added. Both displayed normal and intended behavior.

## Performance Impact
- [x] No impact
- [ ] Minor impact
- [ ] Significant impact (explain below)

## Breaking Changes
- [x] No
- [ ] Yes (describe below)

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] CI passes
- [x] No unnecessary changes included
- [x] Documentation updated (if needed)

<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->