### PR TITLE
feat: teams/avatar switching

### DIFF
--- a/Game/Starlight.Game.Player/AvatarModule.cs
+++ b/Game/Starlight.Game.Player/AvatarModule.cs
@@ -8,30 +8,9 @@ namespace Starlight.Game.Player;
 
 public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guidManager) : IModule
 {
-    #region Beach Simulator
-
-    private const uint TeamId = 1;
-    private static readonly uint[] TeamAvatarIds = [10000005];
-
-    #endregion
-
-    private Avatar[] _team = [];
     private readonly Dictionary<uint, Avatar> _avatars = [];
     private readonly Dictionary<uint, NetAvatar> _avatarState = [];
     private bool _loaded;
-
-    /// The avatars the player walks in with, in slot order.
-    public IReadOnlyList<Avatar> Team
-    {
-        get
-        {
-            lock (player.StateLock)
-            {
-                LoadState();
-                return [.. _team];
-            }
-        }
-    }
 
     /// Every avatar the player currently owns, keyed by avatar ID.
     public IReadOnlyDictionary<uint, Avatar> Avatars
@@ -85,18 +64,19 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
 
         lock (player.StateLock)
         {
-            return new AvatarDataNotify {
-                CurAvatarTeamId = TeamId,
-                ChooseAvatarGuid = _team.FirstOrDefault()?.Guid ?? 0,
+            var teams = player.Module<TeamModule>().Teams;
+            var current = teams.GetValueOrDefault(player.State.CurrentAvatarTeamId);
+            var notify = new AvatarDataNotify {
+                CurAvatarTeamId = current?.Id ?? 0,
+                ChooseAvatarGuid = current?.CurrentAvatarGuid ?? 0,
                 OwnedFlycloakList = [Avatar.DefaultFlycloak],
-                AvatarList = [.. _avatars.Values.Select(avatar => avatar.Info())],
-                AvatarTeamMap = {
-                    [TeamId] = new AvatarTeam {
-                        TeamName = $"Team {TeamId}",
-                        AvatarGuidList = [.._team.Select(avatar => avatar.Guid)]
-                    }
-                }
+                AvatarList = [.. _avatars.Values.Select(avatar => avatar.Info())]
             };
+
+            foreach (var team in teams.Values)
+                notify.AvatarTeamMap.Add(team.Id, team.Info());
+
+            return notify;
         }
     }
 
@@ -268,20 +248,18 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
                 _avatarState.Add(avatar.AvatarId, state);
             }
 
-            var initialTeamAvatarIds =
-                player.State.BornAvatarId is AetherId or LumineId ? [player.State.BornAvatarId] : TeamAvatarIds;
-
             if (player.State.BornState != NetPlayerState.Types.PlayerBornState.Pending)
             {
+                var starterAvatarId = player.State.BornAvatarId is AetherId or LumineId
+                    ? player.State.BornAvatarId
+                    : AetherId;
+
                 // A brand-new player receives the starter roster once. It immediately becomes part of
                 // the persisted state, so reconnects preserve its GUID and born time.
-                foreach (var (slot, avatarId) in initialTeamAvatarIds.Index())
+                if (!_avatars.ContainsKey(starterAvatarId) && CanCreate(starterAvatarId))
                 {
-                    if (_avatars.ContainsKey(avatarId) || !CanCreate(avatarId))
-                        continue;
-
-                    var guid = (ulong)player.Uid << 32 | (uint)(slot * 2 + 1);
-                    var avatar = Avatar.Create(data, avatarId, guid);
+                    var guid = (ulong)player.Uid << 32 | 1;
+                    var avatar = Avatar.Create(data, starterAvatarId, guid);
 
                     var state = new NetAvatar {
                         AvatarId = avatar.AvatarId,
@@ -292,16 +270,11 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
                         WeaponGuid = avatar.WeaponGuid
                     };
 
-                    _avatars.Add(avatarId, avatar);
-                    _avatarState.Add(avatarId, state);
+                    _avatars.Add(starterAvatarId, avatar);
+                    _avatarState.Add(starterAvatarId, state);
                     player.State.Avatars.Add(state);
                 }
             }
-
-            _team = initialTeamAvatarIds
-                .Where(_avatars.ContainsKey)
-                .Select(id => _avatars[id])
-                .ToArray();
         }
     }
 
@@ -343,21 +316,19 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
 
         lock (player.StateLock)
         {
-            _team = [avatar];
-
             player.State.BornAvatarId = avatarId;
 
             player.State.BornState =
                 NetPlayerState.Types.PlayerBornState.Complete;
 
-            notify = new AvatarTeamUpdateNotify {
-                AvatarTeamMap = {
-                    [TeamId] = new AvatarTeam {
-                        TeamName = $"Team {TeamId}",
-                        AvatarGuidList = { avatar.Guid }
-                    }
-                }
-            };
+            player.Module<TeamModule>().Initialize(avatar);
+
+            var teams = player.Module<TeamModule>().Teams;
+
+            notify = new AvatarTeamUpdateNotify();
+
+            foreach (var team in teams.Values)
+                notify.AvatarTeamMap.Add(team.Id, team.Info());
         }
 
         await player.Send(notify);

--- a/Game/Starlight.Game.Player/AvatarModule.cs
+++ b/Game/Starlight.Game.Player/AvatarModule.cs
@@ -66,6 +66,7 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
         {
             var teams = player.Module<TeamModule>().Teams;
             var current = teams.GetValueOrDefault(player.State.CurrentAvatarTeamId);
+
             var notify = new AvatarDataNotify {
                 CurAvatarTeamId = current?.Id ?? 0,
                 ChooseAvatarGuid = current?.CurrentAvatarGuid ?? 0,
@@ -74,7 +75,9 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
             };
 
             foreach (var team in teams.Values)
+            {
                 notify.AvatarTeamMap.Add(team.Id, team.Info());
+            }
 
             return notify;
         }
@@ -250,9 +253,7 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
 
             if (player.State.BornState != NetPlayerState.Types.PlayerBornState.Pending)
             {
-                var starterAvatarId = player.State.BornAvatarId is AetherId or LumineId
-                    ? player.State.BornAvatarId
-                    : AetherId;
+                var starterAvatarId = player.State.BornAvatarId is AetherId or LumineId ? player.State.BornAvatarId : AetherId;
 
                 // A brand-new player receives the starter roster once. It immediately becomes part of
                 // the persisted state, so reconnects preserve its GUID and born time.
@@ -328,7 +329,9 @@ public sealed class AvatarModule(IPlayer player, GameData data, GuidManager guid
             notify = new AvatarTeamUpdateNotify();
 
             foreach (var team in teams.Values)
+            {
                 notify.AvatarTeamMap.Add(team.Id, team.Info());
+            }
         }
 
         await player.Send(notify);

--- a/Game/Starlight.Game.Player/PlayerTeam.cs
+++ b/Game/Starlight.Game.Player/PlayerTeam.cs
@@ -7,7 +7,7 @@ public sealed class PlayerTeam
     public required Avatar[] Avatars { get; set; }
     public required ulong CurrentAvatarGuid { get; set; }
 
-    public Starlight.Protocol.AvatarTeam Info() => new() {
+    public Protocol.AvatarTeam Info() => new() {
         TeamName = Name,
         AvatarGuidList = [.. Avatars.Select(avatar => avatar.Guid)]
     };

--- a/Game/Starlight.Game.Player/PlayerTeam.cs
+++ b/Game/Starlight.Game.Player/PlayerTeam.cs
@@ -1,0 +1,14 @@
+namespace Starlight.Game.Player;
+
+public sealed class PlayerTeam
+{
+    public required uint Id { get; init; }
+    public required string Name { get; set; }
+    public required Avatar[] Avatars { get; set; }
+    public required ulong CurrentAvatarGuid { get; set; }
+
+    public Starlight.Protocol.AvatarTeam Info() => new() {
+        TeamName = Name,
+        AvatarGuidList = [.. Avatars.Select(avatar => avatar.Guid)]
+    };
+}

--- a/Game/Starlight.Game.Player/TeamModule.cs
+++ b/Game/Starlight.Game.Player/TeamModule.cs
@@ -1,0 +1,356 @@
+using Starlight.Game.Modules;
+using Starlight.Protocol;
+using Starlight.Rpc.Proto;
+
+namespace Starlight.Game.Player;
+
+public sealed class TeamModule(IPlayer player) : IModule
+{
+    private const uint DefaultTeamId = 1;
+    private const uint MaxTeamCount = 4;
+    private const int MaxTeamSize = 4;
+
+    private readonly Dictionary<uint, PlayerTeam> _teams = [];
+    private readonly Dictionary<uint, NetAvatarTeam> _teamState = [];
+    private uint _currentTeamId;
+    private bool _loaded;
+
+    public PlayerTeam Current
+    {
+        get
+        {
+            lock (player.StateLock)
+            {
+                LoadState();
+
+                if (!_teams.TryGetValue(_currentTeamId, out var team))
+                    throw new InvalidOperationException("The player does not have an avatar team yet.");
+
+                return Snapshot(team);
+            }
+        }
+    }
+
+    public IReadOnlyDictionary<uint, PlayerTeam> Teams
+    {
+        get
+        {
+            lock (player.StateLock)
+            {
+                LoadState();
+                return _teams.ToDictionary(pair => pair.Key, pair => Snapshot(pair.Value));
+            }
+        }
+    }
+
+    [Lifecycle(LifecycleEvent.PlayerLogin)]
+    public void OnLogin() => LoadState();
+
+    [Opcode]
+    public async Task<SetUpAvatarTeamRsp> OnSetUpAvatarTeam(SetUpAvatarTeamReq msg)
+    {
+        var response = new SetUpAvatarTeamRsp {
+            TeamId = msg.TeamId,
+            CurAvatarGuid = msg.CurAvatarGuid,
+            AvatarTeamGuidList = [.. msg.AvatarTeamGuidList]
+        };
+
+        AvatarTeamUpdateNotify notification;
+        bool activeTeamChanged;
+
+        lock (player.StateLock)
+        {
+            LoadState();
+
+            if (msg.TeamId is 0 or > MaxTeamCount)
+            {
+                response.Retcode = (int)Retcode.RETCODE_CAN_NOT_FIND_TEAM;
+                return response;
+            }
+
+            if (msg.AvatarTeamGuidList.Count == 0)
+            {
+                response.Retcode = (int)Retcode.RETCODE_AVATAR_NOT_EXIST_IN_TEAM;
+                return response;
+            }
+
+            if (msg.AvatarTeamGuidList.Count > MaxTeamSize)
+            {
+                response.Retcode = (int)Retcode.RETCODE_TEAM_COST_EXCEED_LIMIT;
+                return response;
+            }
+
+            if (msg.AvatarTeamGuidList.Distinct().Count() != msg.AvatarTeamGuidList.Count)
+            {
+                response.Retcode = (int)Retcode.RETCODE_DUPLICATE_AVATAR;
+                return response;
+            }
+
+            var owned = player.Module<AvatarModule>().Avatars.Values
+                .ToDictionary(avatar => avatar.Guid);
+
+            if (msg.AvatarTeamGuidList.Any(guid => !owned.ContainsKey(guid)))
+            {
+                response.Retcode = (int)Retcode.RETCODE_CAN_NOT_FIND_AVATAR;
+                return response;
+            }
+
+            var members = msg.AvatarTeamGuidList.Select(guid => owned[guid]).ToArray();
+            var currentAvatarGuid = msg.AvatarTeamGuidList.Contains(msg.CurAvatarGuid)
+                ? msg.CurAvatarGuid
+                : members[0].Guid;
+
+            response.CurAvatarGuid = currentAvatarGuid;
+
+            if (!_teams.TryGetValue(msg.TeamId, out var team))
+            {
+                team = new PlayerTeam {
+                    Id = msg.TeamId,
+                    Name = $"Team {msg.TeamId}",
+                    Avatars = members,
+                    CurrentAvatarGuid = currentAvatarGuid
+                };
+
+                var newState = new NetAvatarTeam {
+                    TeamId = team.Id,
+                    Name = team.Name,
+                    CurrentAvatarGuid = team.CurrentAvatarGuid
+                };
+                newState.AvatarGuids.Add(msg.AvatarTeamGuidList);
+
+                _teams.Add(team.Id, team);
+                _teamState.Add(team.Id, newState);
+                player.State.AvatarTeams.Add(newState);
+            }
+            else
+            {
+                team.Avatars = members;
+                team.CurrentAvatarGuid = currentAvatarGuid;
+
+                var state = _teamState[team.Id];
+                state.AvatarGuids.Clear();
+                state.AvatarGuids.Add(msg.AvatarTeamGuidList);
+                state.CurrentAvatarGuid = team.CurrentAvatarGuid;
+            }
+
+            notification = new AvatarTeamUpdateNotify();
+
+            foreach (var savedTeam in _teams.Values)
+                notification.AvatarTeamMap.Add(savedTeam.Id, savedTeam.Info());
+
+            activeTeamChanged = team.Id == _currentTeamId;
+        }
+
+        await player.Send(notification);
+
+        if (activeTeamChanged)
+            await player.Emit(LifecycleEvent.PlayerTeamChanged);
+
+        return response;
+    }
+
+    [Opcode]
+    public async Task<ChooseCurAvatarTeamRsp> OnChooseCurAvatarTeam(ChooseCurAvatarTeamReq msg)
+    {
+        var response = new ChooseCurAvatarTeamRsp { CurTeamId = msg.TeamId };
+        bool changed;
+
+        lock (player.StateLock)
+        {
+            LoadState();
+
+            if (!_teams.TryGetValue(msg.TeamId, out var team))
+            {
+                response.Retcode = (int)Retcode.RETCODE_CAN_NOT_FIND_TEAM;
+                return response;
+            }
+
+            if (team.Avatars.Length == 0)
+            {
+                response.Retcode = (int)Retcode.RETCODE_AVATAR_NOT_EXIST_IN_TEAM;
+                return response;
+            }
+
+            changed = _currentTeamId != team.Id;
+            _currentTeamId = team.Id;
+            player.State.CurrentAvatarTeamId = team.Id;
+        }
+
+        if (changed)
+            await player.Emit(LifecycleEvent.PlayerTeamChanged);
+
+        return response;
+    }
+
+    [Opcode]
+    public async Task<ChangeAvatarRsp> OnChangeAvatar(ChangeAvatarReq msg)
+    {
+        var response = new ChangeAvatarRsp {
+            CurGuid = msg.Guid,
+            SkillId = msg.SkillId
+        };
+
+        lock (player.StateLock)
+        {
+            LoadState();
+
+            if (!_teams.TryGetValue(_currentTeamId, out var team))
+            {
+                response.Retcode = (int)Retcode.RETCODE_CAN_NOT_FIND_CUR_TEAM;
+                return response;
+            }
+
+            if (team.Avatars.All(avatar => avatar.Guid != msg.Guid))
+            {
+                response.Retcode = (int)Retcode.RETCODE_AVATAR_NOT_EXIST_IN_TEAM;
+                return response;
+            }
+
+            if (team.CurrentAvatarGuid == msg.Guid)
+            {
+                response.Retcode = (int)Retcode.RETCODE_AVATAR_IS_SAME_ONE;
+                return response;
+            }
+
+            team.CurrentAvatarGuid = msg.Guid;
+            _teamState[team.Id].CurrentAvatarGuid = msg.Guid;
+        }
+
+        await player.Emit(LifecycleEvent.PlayerTeamChanged);
+        return response;
+    }
+
+    internal void Initialize(Avatar avatar)
+    {
+        lock (player.StateLock)
+        {
+            LoadState();
+            EnsureTeamSlots(avatar);
+            SelectUsableTeam();
+            PersistTeams();
+        }
+    }
+
+    internal void LoadState()
+    {
+        lock (player.StateLock)
+        {
+            if (_loaded)
+                return;
+
+            _loaded = true;
+
+            var avatars = player.Module<AvatarModule>().Avatars.Values
+                .ToDictionary(avatar => avatar.Guid);
+
+            foreach (var state in player.State.AvatarTeams.Take((int)MaxTeamCount))
+            {
+                if (state.TeamId is 0 or > MaxTeamCount || _teams.ContainsKey(state.TeamId))
+                    continue;
+
+                var members = state.AvatarGuids
+                    .Distinct()
+                    .Where(avatars.ContainsKey)
+                    .Take(MaxTeamSize)
+                    .Select(guid => avatars[guid])
+                    .ToArray();
+
+                state.AvatarGuids.Clear();
+                state.AvatarGuids.Add(members.Select(avatar => avatar.Guid));
+
+                if (members.Length == 0)
+                    state.CurrentAvatarGuid = 0;
+                else if (members.All(avatar => avatar.Guid != state.CurrentAvatarGuid))
+                    state.CurrentAvatarGuid = members[0].Guid;
+
+                if (string.IsNullOrWhiteSpace(state.Name))
+                    state.Name = $"Team {state.TeamId}";
+
+                var team = new PlayerTeam {
+                    Id = state.TeamId,
+                    Name = state.Name,
+                    Avatars = members,
+                    CurrentAvatarGuid = state.CurrentAvatarGuid
+                };
+
+                _teams.Add(team.Id, team);
+                _teamState.Add(team.Id, state);
+            }
+
+            if (player.State.BornState != NetPlayerState.Types.PlayerBornState.Pending)
+            {
+                var starter = avatars.Values.FirstOrDefault(avatar =>
+                                  avatar.AvatarId == player.State.BornAvatarId)
+                              ?? avatars.Values.FirstOrDefault();
+
+                EnsureTeamSlots(starter);
+            }
+
+            _currentTeamId = player.State.CurrentAvatarTeamId;
+            SelectUsableTeam();
+            PersistTeams();
+        }
+    }
+
+    private void EnsureTeamSlots(Avatar? starter)
+    {
+        for (uint teamId = 1; teamId <= MaxTeamCount; teamId++)
+        {
+            if (_teams.ContainsKey(teamId))
+                continue;
+
+            Avatar[] members = teamId == DefaultTeamId && starter is not null
+                ? new[] { starter }
+                : [];
+
+            AddTeam(teamId, members);
+        }
+    }
+
+    private void AddTeam(uint teamId, Avatar[] members)
+    {
+        var currentAvatarGuid = members.FirstOrDefault()?.Guid ?? 0;
+        var state = new NetAvatarTeam {
+            TeamId = teamId,
+            Name = $"Team {teamId}",
+            CurrentAvatarGuid = currentAvatarGuid
+        };
+        state.AvatarGuids.Add(members.Select(avatar => avatar.Guid));
+
+        var team = new PlayerTeam {
+            Id = state.TeamId,
+            Name = state.Name,
+            Avatars = members,
+            CurrentAvatarGuid = state.CurrentAvatarGuid
+        };
+
+        _teams.Add(team.Id, team);
+        _teamState.Add(team.Id, state);
+        player.State.AvatarTeams.Add(state);
+    }
+
+    private void SelectUsableTeam()
+    {
+        if (!_teams.TryGetValue(_currentTeamId, out var current) || current.Avatars.Length == 0)
+        {
+            _currentTeamId = _teams.Values
+                .FirstOrDefault(team => team.Avatars.Length > 0)?.Id ?? 0;
+        }
+
+        player.State.CurrentAvatarTeamId = _currentTeamId;
+    }
+
+    private void PersistTeams()
+    {
+        player.State.AvatarTeams.Clear();
+        player.State.AvatarTeams.Add(
+            _teamState.OrderBy(pair => pair.Key).Select(pair => pair.Value));
+    }
+
+    private static PlayerTeam Snapshot(PlayerTeam team) => new() {
+        Id = team.Id,
+        Name = team.Name,
+        Avatars = [.. team.Avatars],
+        CurrentAvatarGuid = team.CurrentAvatarGuid
+    };
+}

--- a/Game/Starlight.Game.Player/TeamModule.cs
+++ b/Game/Starlight.Game.Player/TeamModule.cs
@@ -96,9 +96,7 @@ public sealed class TeamModule(IPlayer player) : IModule
             }
 
             var members = msg.AvatarTeamGuidList.Select(guid => owned[guid]).ToArray();
-            var currentAvatarGuid = msg.AvatarTeamGuidList.Contains(msg.CurAvatarGuid)
-                ? msg.CurAvatarGuid
-                : members[0].Guid;
+            var currentAvatarGuid = msg.AvatarTeamGuidList.Contains(msg.CurAvatarGuid) ? msg.CurAvatarGuid : members[0].Guid;
 
             response.CurAvatarGuid = currentAvatarGuid;
 
@@ -121,8 +119,7 @@ public sealed class TeamModule(IPlayer player) : IModule
                 _teams.Add(team.Id, team);
                 _teamState.Add(team.Id, newState);
                 player.State.AvatarTeams.Add(newState);
-            }
-            else
+            } else
             {
                 team.Avatars = members;
                 team.CurrentAvatarGuid = currentAvatarGuid;
@@ -136,7 +133,9 @@ public sealed class TeamModule(IPlayer player) : IModule
             notification = new AvatarTeamUpdateNotify();
 
             foreach (var savedTeam in _teams.Values)
+            {
                 notification.AvatarTeamMap.Add(savedTeam.Id, savedTeam.Info());
+            }
 
             activeTeamChanged = team.Id == _currentTeamId;
         }
@@ -299,9 +298,7 @@ public sealed class TeamModule(IPlayer player) : IModule
             if (_teams.ContainsKey(teamId))
                 continue;
 
-            Avatar[] members = teamId == DefaultTeamId && starter is not null
-                ? new[] { starter }
-                : [];
+            var members = teamId == DefaultTeamId && starter is not null ? new[] { starter } : [];
 
             AddTeam(teamId, members);
         }
@@ -310,6 +307,7 @@ public sealed class TeamModule(IPlayer player) : IModule
     private void AddTeam(uint teamId, Avatar[] members)
     {
         var currentAvatarGuid = members.FirstOrDefault()?.Guid ?? 0;
+
         var state = new NetAvatarTeam {
             TeamId = teamId,
             Name = $"Team {teamId}",
@@ -343,6 +341,7 @@ public sealed class TeamModule(IPlayer player) : IModule
     private void PersistTeams()
     {
         player.State.AvatarTeams.Clear();
+
         player.State.AvatarTeams.Add(
             _teamState.OrderBy(pair => pair.Key).Select(pair => pair.Value));
     }

--- a/Game/Starlight.Game.World/SceneModule.cs
+++ b/Game/Starlight.Game.World/SceneModule.cs
@@ -101,10 +101,11 @@ public sealed class SceneModule(IPlayer player) : IModule
             };
         }
 
-        if (currentChanged && current is not null)
+        if (currentChanged && previous is not null && current is not null)
         {
             yield return new SceneEntityAppearNotify {
                 AppearType = VisionType.VISION_TYPE_REPLACE,
+                Param = previous.EntityId,
                 EntityList = { current.Info }
             };
         }

--- a/Game/Starlight.Game.World/SceneModule.cs
+++ b/Game/Starlight.Game.World/SceneModule.cs
@@ -85,7 +85,9 @@ public sealed class SceneModule(IPlayer player) : IModule
         _teamEntities.Clear();
 
         foreach (var (guid, entity) in nextEntities)
+        {
             _teamEntities.Add(guid, entity);
+        }
 
         _currentAvatarGuid = team.CurrentAvatarGuid;
 

--- a/Game/Starlight.Game.World/SceneModule.cs
+++ b/Game/Starlight.Game.World/SceneModule.cs
@@ -17,6 +17,8 @@ public sealed class SceneModule(IPlayer player) : IModule
     private static readonly Vector SpawnPosition = new() { X = 2747, Y = 194, Z = -1719 };
 
     private readonly List<SceneEntityInfo> _spawned = [];
+    private readonly Dictionary<ulong, AvatarEntity> _teamEntities = [];
+    private ulong _currentAvatarGuid;
 
     #endregion
 
@@ -29,6 +31,81 @@ public sealed class SceneModule(IPlayer player) : IModule
     {
         player.Module<WorldModule>().EnterOwnWorld();
         return EnterScene();
+    }
+
+    [Lifecycle(LifecycleEvent.PlayerTeamChanged)]
+    public IEnumerable<IMessage> OnTeamChanged()
+    {
+        var module = player.Module<WorldModule>();
+        var scene = module.Scene;
+
+        if (scene is null)
+            yield break;
+
+        var team = player.Module<TeamModule>().Current;
+        var notification = new SceneTeamUpdateNotify();
+        var nextEntities = new Dictionary<ulong, AvatarEntity>();
+
+        foreach (var avatar in team.Avatars)
+        {
+            if (!_teamEntities.TryGetValue(avatar.Guid, out var entity))
+            {
+                entity = AvatarEntity.Create(
+                    module.World,
+                    player.Uid,
+                    module.PeerId,
+                    avatar,
+                    SpawnPosition);
+            }
+
+            nextEntities.Add(avatar.Guid, entity);
+
+            var isCurrent = avatar.Guid == team.CurrentAvatarGuid;
+
+            notification.SceneTeamAvatarList.Add(new SceneTeamAvatar {
+                PlayerUid = player.Uid,
+                SceneId = scene.Id,
+                AvatarGuid = avatar.Guid,
+                EntityId = entity.EntityId,
+                WeaponGuid = avatar.WeaponGuid,
+                WeaponEntityId = entity.WeaponEntityId,
+                AbilityControlBlock = avatar.ControlBlock(),
+                AvatarAbilityInfo = new AbilitySyncStateInfo(),
+                WeaponAbilityInfo = new AbilitySyncStateInfo(),
+                SceneEntityInfo = entity.Info,
+                IsOnScene = isCurrent,
+                IsPlayerCurAvatar = isCurrent
+            });
+        }
+
+        _teamEntities.TryGetValue(_currentAvatarGuid, out var previous);
+        nextEntities.TryGetValue(team.CurrentAvatarGuid, out var current);
+        var currentChanged = _currentAvatarGuid != team.CurrentAvatarGuid;
+
+        _teamEntities.Clear();
+
+        foreach (var (guid, entity) in nextEntities)
+            _teamEntities.Add(guid, entity);
+
+        _currentAvatarGuid = team.CurrentAvatarGuid;
+
+        yield return notification;
+
+        if (currentChanged && previous is not null)
+        {
+            yield return new SceneEntityDisappearNotify {
+                DisappearType = VisionType.VISION_TYPE_REPLACE,
+                EntityList = { previous.EntityId }
+            };
+        }
+
+        if (currentChanged && current is not null)
+        {
+            yield return new SceneEntityAppearNotify {
+                AppearType = VisionType.VISION_TYPE_REPLACE,
+                EntityList = { current.Info }
+            };
+        }
     }
 
     [Opcode]
@@ -75,14 +152,18 @@ public sealed class SceneModule(IPlayer player) : IModule
         };
 
         var teamUpdate = new SceneTeamUpdateNotify();
+        var team = player.Module<TeamModule>().Current;
 
         _spawned.Clear();
+        _teamEntities.Clear();
+        _currentAvatarGuid = team.CurrentAvatarGuid;
 
-        foreach (var (slot, avatar) in player.Module<AvatarModule>().Team.Index())
+        foreach (var avatar in team.Avatars)
         {
             var entity = AvatarEntity.Create(world, player.Uid, module.PeerId, avatar, SpawnPosition);
+            _teamEntities.Add(avatar.Guid, entity);
 
-            var isCurrent = slot == 0;
+            var isCurrent = avatar.Guid == team.CurrentAvatarGuid;
 
             if (isCurrent)
             {

--- a/Libraries/Starlight.Protocol/Lifecycle.cs
+++ b/Libraries/Starlight.Protocol/Lifecycle.cs
@@ -24,7 +24,9 @@ public enum LifecycleEvent
     /// Sent when the player data is being saved to the database, before a PlayerDisconnect.
     PlayerSaving = 2,
     /// Sent after a new player has selected their Traveler and nickname.
-    PlayerBorn = 3
+    PlayerBorn = 3,
+    /// Sent after the active avatar team changes and its scene representation must be refreshed.
+    PlayerTeamChanged = 4
 }
 
 public enum LifecycleOrder

--- a/Libraries/Starlight.Rpc/Protobuf/starlight.player.proto
+++ b/Libraries/Starlight.Rpc/Protobuf/starlight.player.proto
@@ -36,6 +36,15 @@ message NetPlayerState {
 
   PlayerBornState born_state = 4;
   uint32 born_avatar_id = 5;
+  repeated NetAvatarTeam avatar_teams = 6;
+  uint32 current_avatar_team_id = 7;
+}
+
+message NetAvatarTeam {
+  uint32 team_id = 1;
+  string name = 2;
+  repeated uint64 avatar_guids = 3;
+  uint64 current_avatar_guid = 4;
 }
 
 message NetMaterial {

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -74,9 +74,19 @@ public sealed class AvatarEquipTests
             NetPlayerState.Types.PlayerBornState.Complete,
             player.State.BornState);
 
-        var traveler = Assert.Single(player.Module<AvatarModule>().Team);
+        var traveler = Assert.Single(player.Module<TeamModule>().Current.Avatars);
         Assert.Equal(expected: 10000007u, traveler.AvatarId);
         Assert.Single(player.State.Avatars, state => state.AvatarId == 10000007);
+
+        Assert.Equal(expected: 4, player.State.AvatarTeams.Count);
+        var team = player.State.AvatarTeams.Single(state => state.TeamId == 1);
+        Assert.Equal(expected: 1u, team.TeamId);
+        Assert.Equal(traveler.Guid, Assert.Single(team.AvatarGuids));
+        Assert.Equal(traveler.Guid, team.CurrentAvatarGuid);
+        Assert.Equal(team.TeamId, player.State.CurrentAvatarTeamId);
+
+        var teamNotify = Assert.Single(sent.OfType<AvatarTeamUpdateNotify>());
+        Assert.Equal(expected: 4, teamNotify.AvatarTeamMap.Count);
 
         var nicknameNotify = Assert.Single(sent.OfType<PlayerNicknameNotify>());
         Assert.Equal("Lumine", nicknameNotify.Nickname);
@@ -94,13 +104,24 @@ public sealed class AvatarEquipTests
         var (reconnected, _) = Player(uid: 1001, data);
         reconnected.State = restored.State ?? new NetPlayerState();
         reconnected.Profile = restored.Profile ?? new NetPlayerProfile();
-        await reconnected.Module<AvatarModule>().OnLogin();
+        var login = await reconnected.Module<AvatarModule>().OnLogin();
 
         Assert.Equal("Lumine", reconnected.Profile.Nickname);
 
         Assert.Equal(
             expected: 10000007u,
-            Assert.Single(reconnected.Module<AvatarModule>().Team).AvatarId);
+            Assert.Single(reconnected.Module<TeamModule>().Current.Avatars).AvatarId);
+
+        var restoredTeam = reconnected.Module<TeamModule>().Current;
+        Assert.Equal(expected: 1u, restoredTeam.Id);
+        Assert.Equal(expected: 10000007u, Assert.Single(restoredTeam.Avatars).AvatarId);
+        Assert.Equal(restoredTeam.Avatars[0].Guid, restoredTeam.CurrentAvatarGuid);
+        Assert.Equal(restoredTeam.Id, login.CurAvatarTeamId);
+        Assert.Equal(restoredTeam.CurrentAvatarGuid, login.ChooseAvatarGuid);
+        Assert.Equal(restoredTeam.Name, login.AvatarTeamMap[restoredTeam.Id].TeamName);
+        Assert.Equal(
+            restoredTeam.Avatars.Select(avatar => avatar.Guid),
+            login.AvatarTeamMap[restoredTeam.Id].AvatarGuidList);
     }
 
     [Fact]
@@ -145,6 +166,302 @@ public sealed class AvatarEquipTests
         var restored = reconnected.Module<AvatarModule>().Avatars[10000005];
         Assert.Equal(weapon.Guid, restored.WeaponGuid);
         Assert.Equal(weapon.ItemId, restored.WeaponItemId);
+    }
+
+    [Fact]
+    public async Task SetUpAvatarTeam_UpdatesNotifiesAndPersists()
+    {
+        var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var first = avatars.Avatars[10000005];
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+        sent.Clear();
+
+        var response = await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = 1,
+            CurAvatarGuid = second.Guid,
+            AvatarTeamGuidList = { second.Guid, first.Guid }
+        });
+
+        Assert.Equal(expected: 0, response.Retcode);
+        Assert.Equal(expected: 1u, response.TeamId);
+        Assert.Equal(second.Guid, response.CurAvatarGuid);
+        Assert.Equal([second.Guid, first.Guid], response.AvatarTeamGuidList);
+
+        var current = teams.Current;
+        Assert.Equal([second.Guid, first.Guid], current.Avatars.Select(avatar => avatar.Guid));
+        Assert.Equal(second.Guid, current.CurrentAvatarGuid);
+
+        var state = player.State.AvatarTeams.Single(state => state.TeamId == 1);
+        Assert.Equal([second.Guid, first.Guid], state.AvatarGuids);
+        Assert.Equal(second.Guid, state.CurrentAvatarGuid);
+
+        var notify = Assert.IsType<AvatarTeamUpdateNotify>(Assert.Single(sent));
+        Assert.Equal([second.Guid, first.Guid], notify.AvatarTeamMap[1].AvatarGuidList);
+
+        var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+        var (reconnected, _) = Player(uid: 1001, data);
+        reconnected.State = persisted;
+        await reconnected.Module<AvatarModule>().OnLogin();
+
+        var restored = reconnected.Module<TeamModule>().Current;
+        Assert.Equal([second.Guid, first.Guid], restored.Avatars.Select(avatar => avatar.Guid));
+        Assert.Equal(second.Guid, restored.CurrentAvatarGuid);
+    }
+
+    [Fact]
+    public async Task SetUpAvatarTeam_InvalidRoster_DoesNotMutateState()
+    {
+        var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var original = teams.Current;
+        sent.Clear();
+
+        var duplicate = await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = original.Id,
+            CurAvatarGuid = original.CurrentAvatarGuid,
+            AvatarTeamGuidList = { original.CurrentAvatarGuid, original.CurrentAvatarGuid }
+        });
+
+        Assert.Equal((int)Retcode.RETCODE_DUPLICATE_AVATAR, duplicate.Retcode);
+        Assert.Empty(sent);
+
+        var current = teams.Current;
+        Assert.Equal(original.Avatars.Select(avatar => avatar.Guid),
+            current.Avatars.Select(avatar => avatar.Guid));
+        Assert.Equal(original.CurrentAvatarGuid, current.CurrentAvatarGuid);
+    }
+
+    [Fact]
+    public async Task SetUpAvatarTeam_NotifyContainsEverySavedTeam()
+    {
+        var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var first = avatars.Avatars[10000005];
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+
+        var create = await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = 2,
+            CurAvatarGuid = second.Guid,
+            AvatarTeamGuidList = { second.Guid }
+        });
+
+        Assert.Equal(expected: 0, create.Retcode);
+        Assert.Equal(expected: 4, teams.Teams.Count);
+
+        sent.Clear();
+
+        await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = 1,
+            CurAvatarGuid = first.Guid,
+            AvatarTeamGuidList = { first.Guid, second.Guid }
+        });
+
+        var notify = Assert.IsType<AvatarTeamUpdateNotify>(Assert.Single(sent));
+        Assert.Equal(expected: 4, notify.AvatarTeamMap.Count);
+        Assert.Equal([first.Guid, second.Guid], notify.AvatarTeamMap[1].AvatarGuidList);
+        Assert.Equal([second.Guid], notify.AvatarTeamMap[2].AvatarGuidList);
+    }
+
+    [Fact]
+    public async Task SetUpAvatarTeam_EmptySlot_SelectsFirstAddedAvatar()
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+
+        var response = await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = 2,
+            CurAvatarGuid = 0,
+            AvatarTeamGuidList = { second.Guid }
+        });
+
+        Assert.Equal(expected: 0, response.Retcode);
+        Assert.Equal(second.Guid, response.CurAvatarGuid);
+
+        var team = teams.Teams[2];
+        Assert.Equal(second.Guid, team.CurrentAvatarGuid);
+        Assert.Equal(
+            second.Guid,
+            player.State.AvatarTeams.Single(state => state.TeamId == 2).CurrentAvatarGuid);
+    }
+
+    [Fact]
+    public async Task SetUpAvatarTeam_ConcurrentRequests_KeepRuntimeAndStateConsistent()
+    {
+        var data = Data();
+        var (player, sent) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var first = avatars.Avatars[10000005];
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+        sent.Clear();
+
+        var responses = await Task.WhenAll(
+            Enumerable.Range(start: 0, count: 100).Select(index => {
+                var members = index % 2 == 0
+                    ? new[] { first.Guid, second.Guid }
+                    : [second.Guid, first.Guid];
+
+                return teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+                    TeamId = 1,
+                    CurAvatarGuid = members[0],
+                    AvatarTeamGuidList = [.. members]
+                });
+            }));
+
+        Assert.All(responses, response => Assert.Equal(expected: 0, response.Retcode));
+
+        var current = teams.Current;
+        var state = player.State.AvatarTeams.Single(state => state.TeamId == 1);
+        Assert.Equal(current.Avatars.Select(avatar => avatar.Guid), state.AvatarGuids);
+        Assert.Equal(current.CurrentAvatarGuid, state.CurrentAvatarGuid);
+        Assert.Contains(current.CurrentAvatarGuid, state.AvatarGuids);
+    }
+
+    [Fact]
+    public async Task ChangeAvatar_UpdatesSelectionAndPersists()
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var first = avatars.Avatars[10000005];
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+
+        await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = 1,
+            CurAvatarGuid = first.Guid,
+            AvatarTeamGuidList = { first.Guid, second.Guid }
+        });
+
+        var response = await teams.OnChangeAvatar(new ChangeAvatarReq {
+            Guid = second.Guid,
+            SkillId = 123
+        });
+
+        Assert.Equal(expected: 0, response.Retcode);
+        Assert.Equal(second.Guid, response.CurGuid);
+        Assert.Equal(expected: 123u, response.SkillId);
+        Assert.Equal(second.Guid, teams.Current.CurrentAvatarGuid);
+        Assert.Equal(
+            second.Guid,
+            player.State.AvatarTeams.Single(state => state.TeamId == 1).CurrentAvatarGuid);
+
+        var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+        var (reconnected, _) = Player(uid: 1001, data);
+        reconnected.State = persisted;
+        await reconnected.Module<AvatarModule>().OnLogin();
+
+        Assert.Equal(second.Guid, reconnected.Module<TeamModule>().Current.CurrentAvatarGuid);
+    }
+
+    [Fact]
+    public async Task ChangeAvatar_AvatarOutsideCurrentTeam_IsRejected()
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var original = teams.Current;
+        var (outside, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(outside);
+
+        var response = await teams.OnChangeAvatar(new ChangeAvatarReq { Guid = outside.Guid });
+
+        Assert.Equal((int)Retcode.RETCODE_AVATAR_NOT_EXIST_IN_TEAM, response.Retcode);
+        Assert.Equal(original.CurrentAvatarGuid, teams.Current.CurrentAvatarGuid);
+        Assert.Equal(
+            original.CurrentAvatarGuid,
+            player.State.AvatarTeams.Single(state => state.TeamId == 1).CurrentAvatarGuid);
+    }
+
+    [Fact]
+    public async Task ChooseCurAvatarTeam_SwitchesAndPersistsCurrentTeam()
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+
+        await avatars.OnLogin();
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+
+        await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+            TeamId = 2,
+            CurAvatarGuid = second.Guid,
+            AvatarTeamGuidList = { second.Guid }
+        });
+
+        var response = await teams.OnChooseCurAvatarTeam(
+            new ChooseCurAvatarTeamReq { TeamId = 2 });
+
+        Assert.Equal(expected: 0, response.Retcode);
+        Assert.Equal(expected: 2u, response.CurTeamId);
+        Assert.Equal(expected: 2u, teams.Current.Id);
+        Assert.Equal(expected: 2u, player.State.CurrentAvatarTeamId);
+        Assert.Equal(second.Guid, teams.Current.CurrentAvatarGuid);
+
+        var persisted = NetPlayerState.Parser.ParseFrom(player.State.ToByteArray());
+        var (reconnected, _) = Player(uid: 1001, data);
+        reconnected.State = persisted;
+        var login = await reconnected.Module<AvatarModule>().OnLogin();
+
+        Assert.Equal(expected: 2u, reconnected.Module<TeamModule>().Current.Id);
+        Assert.Equal(expected: 2u, login.CurAvatarTeamId);
+        Assert.Equal(second.Guid, login.ChooseAvatarGuid);
+    }
+
+    [Fact]
+    public async Task ChooseCurAvatarTeam_EmptyTeam_IsRejected()
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data);
+        var teams = player.Module<TeamModule>();
+
+        await player.Module<AvatarModule>().OnLogin();
+
+        var response = await teams.OnChooseCurAvatarTeam(
+            new ChooseCurAvatarTeamReq { TeamId = 2 });
+
+        Assert.Equal((int)Retcode.RETCODE_AVATAR_NOT_EXIST_IN_TEAM, response.Retcode);
+        Assert.Equal(expected: 1u, teams.Current.Id);
+        Assert.Equal(expected: 1u, player.State.CurrentAvatarTeamId);
     }
 
     [Fact]
@@ -222,6 +539,7 @@ public sealed class AvatarEquipTests
         var guidManager = new GuidManager(serverId: 1);
         registry.AddModule<InventoryModule>((_, player) => new InventoryModule(player, guidManager, data));
         registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data, guidManager));
+        registry.AddModule<TeamModule>((_, player) => new TeamModule(player));
         registry.AddModule<BornModule>((_, player) => new BornModule(player));
         registry.Build();
 
@@ -229,7 +547,9 @@ public sealed class AvatarEquipTests
         var sent = new List<IMessage>();
 
         _ = client.Subscribe(GameSubjects.OutboundPacket, message => {
-            sent.Add(message.Decode<IMessage>());
+            lock (sent)
+                sent.Add(message.Decode<IMessage>());
+
             return Task.CompletedTask;
         });
 

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -7,6 +7,7 @@ using Starlight.Game.Player;
 using Starlight.Game.Resources;
 using Starlight.Game.Resources.Binary;
 using Starlight.Game.Resources.Excel;
+using Starlight.Game.World;
 using Starlight.Protocol;
 using Starlight.Rpc;
 using Starlight.Rpc.Proto;
@@ -388,6 +389,76 @@ public sealed class AvatarEquipTests
         Assert.Equal(second.Guid, reconnected.Module<TeamModule>().Current.CurrentAvatarGuid);
     }
 
+    [Theory]
+    [InlineData("change")]
+    [InlineData("setup")]
+    [InlineData("choose")]
+    public async Task TeamChange_ReplacementAppearReferencesDisappearedEntity(string operation)
+    {
+        var data = Data();
+        var (player, _) = Player(uid: 1001, data, includeWorld: true);
+        var avatars = player.Module<AvatarModule>();
+        var teams = player.Module<TeamModule>();
+        var world = player.Module<WorldModule>();
+        var scene = player.Module<SceneModule>();
+
+        await avatars.OnLogin();
+        var first = avatars.Avatars[10000005];
+        var (second, added) = await avatars.AddAvatar(10000007);
+        Assert.True(added);
+        Assert.NotNull(second);
+
+        if (operation == "change")
+        {
+            await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+                TeamId = 1,
+                CurAvatarGuid = first.Guid,
+                AvatarTeamGuidList = { first.Guid, second.Guid }
+            });
+        } else if (operation == "choose")
+        {
+            await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+                TeamId = 2,
+                CurAvatarGuid = second.Guid,
+                AvatarTeamGuidList = { second.Guid }
+            });
+        }
+
+        world.EnterOwnWorld();
+        _ = scene.OnEnterSceneReady(new EnterSceneReadyReq { EnterSceneToken = 1 }).ToArray();
+
+        var enter = Assert.Single(
+            scene.OnSceneInit(new SceneInitFinishReq { EnterSceneToken = 1 })
+                .OfType<PlayerEnterSceneInfoNotify>());
+
+        switch (operation)
+        {
+            case "change":
+                await teams.OnChangeAvatar(new ChangeAvatarReq { Guid = second.Guid });
+                break;
+            case "setup":
+                await teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
+                    TeamId = 1,
+                    CurAvatarGuid = second.Guid,
+                    AvatarTeamGuidList = { first.Guid, second.Guid }
+                });
+                break;
+            case "choose":
+                await teams.OnChooseCurAvatarTeam(new ChooseCurAvatarTeamReq { TeamId = 2 });
+                break;
+        }
+
+        var notifications = scene.OnTeamChanged().ToArray();
+        var disappear = Assert.Single(notifications.OfType<SceneEntityDisappearNotify>());
+        var appear = Assert.Single(notifications.OfType<SceneEntityAppearNotify>());
+        var disappearedEntityId = Assert.Single(disappear.EntityList);
+
+        Assert.Equal(VisionType.VISION_TYPE_REPLACE, disappear.DisappearType);
+        Assert.Equal(VisionType.VISION_TYPE_REPLACE, appear.AppearType);
+        Assert.Equal(enter.CurAvatarEntityId, disappearedEntityId);
+        Assert.Equal(disappearedEntityId, appear.Param);
+    }
+
     [Fact]
     public async Task ChangeAvatar_AvatarOutsideCurrentTeam_IsRejected()
     {
@@ -535,7 +606,11 @@ public sealed class AvatarEquipTests
         Assert.Single(player.State.Avatars, state => state.AvatarId == 10000007);
     }
 
-    private static (StarlightPlayer Player, List<IMessage> Sent) Player(uint uid, GameData data)
+    private static (StarlightPlayer Player, List<IMessage> Sent) Player(
+        uint uid,
+        GameData data,
+        bool includeWorld = false
+    )
     {
         var services = new ServiceCollection().AddLogging().BuildServiceProvider();
         var registry = new ModuleRegistry();
@@ -544,6 +619,14 @@ public sealed class AvatarEquipTests
         registry.AddModule<AvatarModule>((_, player) => new AvatarModule(player, data, guidManager));
         registry.AddModule<TeamModule>((_, player) => new TeamModule(player));
         registry.AddModule<BornModule>((_, player) => new BornModule(player));
+
+        if (includeWorld)
+        {
+            var worlds = new WorldManager();
+            registry.AddModule<WorldModule>((_, player) => new WorldModule(player, worlds));
+            registry.AddModule<SceneModule>((_, player) => new SceneModule(player));
+        }
+
         registry.Build();
 
         var (client, server) = DirectTunnel.CreatePair();

--- a/Tests/Starlight.Tests/AvatarEquipTests.cs
+++ b/Tests/Starlight.Tests/AvatarEquipTests.cs
@@ -119,6 +119,7 @@ public sealed class AvatarEquipTests
         Assert.Equal(restoredTeam.Id, login.CurAvatarTeamId);
         Assert.Equal(restoredTeam.CurrentAvatarGuid, login.ChooseAvatarGuid);
         Assert.Equal(restoredTeam.Name, login.AvatarTeamMap[restoredTeam.Id].TeamName);
+
         Assert.Equal(
             restoredTeam.Avatars.Select(avatar => avatar.Guid),
             login.AvatarTeamMap[restoredTeam.Id].AvatarGuidList);
@@ -237,6 +238,7 @@ public sealed class AvatarEquipTests
         Assert.Empty(sent);
 
         var current = teams.Current;
+
         Assert.Equal(original.Avatars.Select(avatar => avatar.Guid),
             current.Avatars.Select(avatar => avatar.Guid));
         Assert.Equal(original.CurrentAvatarGuid, current.CurrentAvatarGuid);
@@ -303,6 +305,7 @@ public sealed class AvatarEquipTests
 
         var team = teams.Teams[2];
         Assert.Equal(second.Guid, team.CurrentAvatarGuid);
+
         Assert.Equal(
             second.Guid,
             player.State.AvatarTeams.Single(state => state.TeamId == 2).CurrentAvatarGuid);
@@ -325,9 +328,7 @@ public sealed class AvatarEquipTests
 
         var responses = await Task.WhenAll(
             Enumerable.Range(start: 0, count: 100).Select(index => {
-                var members = index % 2 == 0
-                    ? new[] { first.Guid, second.Guid }
-                    : [second.Guid, first.Guid];
+                var members = index % 2 == 0 ? new[] { first.Guid, second.Guid } : [second.Guid, first.Guid];
 
                 return teams.OnSetUpAvatarTeam(new SetUpAvatarTeamReq {
                     TeamId = 1,
@@ -374,6 +375,7 @@ public sealed class AvatarEquipTests
         Assert.Equal(second.Guid, response.CurGuid);
         Assert.Equal(expected: 123u, response.SkillId);
         Assert.Equal(second.Guid, teams.Current.CurrentAvatarGuid);
+
         Assert.Equal(
             second.Guid,
             player.State.AvatarTeams.Single(state => state.TeamId == 1).CurrentAvatarGuid);
@@ -404,6 +406,7 @@ public sealed class AvatarEquipTests
 
         Assert.Equal((int)Retcode.RETCODE_AVATAR_NOT_EXIST_IN_TEAM, response.Retcode);
         Assert.Equal(original.CurrentAvatarGuid, teams.Current.CurrentAvatarGuid);
+
         Assert.Equal(
             original.CurrentAvatarGuid,
             player.State.AvatarTeams.Single(state => state.TeamId == 1).CurrentAvatarGuid);
@@ -548,7 +551,9 @@ public sealed class AvatarEquipTests
 
         _ = client.Subscribe(GameSubjects.OutboundPacket, message => {
             lock (sent)
+            {
                 sent.Add(message.Decode<IMessage>());
+            }
 
             return Task.CompletedTask;
         });

--- a/Tests/Starlight.Tests/PlayerManagerTests.cs
+++ b/Tests/Starlight.Tests/PlayerManagerTests.cs
@@ -16,6 +16,7 @@ public sealed class PlayerManagerTests
         Assert.Equal(expected: 1, (int)LifecycleEvent.PlayerDisconnect);
         Assert.Equal(expected: 2, (int)LifecycleEvent.PlayerSaving);
         Assert.Equal(expected: 3, (int)LifecycleEvent.PlayerBorn);
+        Assert.Equal(expected: 4, (int)LifecycleEvent.PlayerTeamChanged);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->

## Summary
Adds the feature of switching loadouts, avatars in game and changing loadouts.

## Related Issues
None

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Documentation
- [ ] Other (describe):

## Changes
- New RPC data
- New `PlayerTeam` model
- New team module for persistence, setup, team selection and avatar switching
- Added `PlayerTeamChanged` lifecycle
- New tests

## Implementation Details
Explain any non-trivial design decisions or trade-offs.

## Testing
- [x] Unit tests added/updated
- [x] Existing tests pass
- [x] Manually tested

Tested in-game.

## Performance Impact
- [x] No impact
- [ ] Minor impact
- [ ] Significant impact (explain below)

## Breaking Changes
- [x] No
- [ ] Yes (describe below)

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] CI passes
- [x] No unnecessary changes included
- [x] Documentation updated (if needed)

<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->