### PR TITLE
feat: verifySToken route

### DIFF
--- a/Source/Starlight.SDK/Http/Endpoints/PassportEndpoints.cs
+++ b/Source/Starlight.SDK/Http/Endpoints/PassportEndpoints.cs
@@ -144,7 +144,7 @@ public static class PassportEndpoints
         acc.Country = country;
         await db.SaveChangesAsync(ct);
 
-        logger.LogInformation("Verified stoken for account id {Id}", acc.Id);
+        logger.LogInformation("Verified SToken for account id {Id}", acc.Id);
 
         return Results.Ok(ApiResponse.Ok(BuildLoginData(
             acc,

--- a/Source/Starlight.SDK/Http/Endpoints/PassportEndpoints.cs
+++ b/Source/Starlight.SDK/Http/Endpoints/PassportEndpoints.cs
@@ -51,6 +51,10 @@ public static class PassportEndpoints
             // Per-platform UI feature flags for the SDK login screen.
             routes.MapGet($"{prefix}/getSwitchStatus", HandleGetSwitchStatus);
         }
+
+        routes.MapPost(
+            "/hk4e_global/account/ma-passport/token/verifySToken",
+            HandleVerifySToken);
     }
 
     private static async Task<IResult> HandleGetConfig(
@@ -80,6 +84,75 @@ public static class PassportEndpoints
             DisableMmt = sdkConfig.MaPassport.DisableMmt,
             ShowBirthday = sdkConfig.MaPassport.ShowBirthday.ToString().ToLowerInvariant()
         }));
+    }
+
+    /// <summary>
+    /// Handles <c>POST /hk4e_global/account/ma-passport/token/verifySToken</c>.
+    /// Validates a previously-issued token and returns it with the masked
+    /// user-info block.
+    /// </summary>
+    private static async Task<IResult> HandleVerifySToken(
+        HttpContext httpContext,
+        [FromBody] MaPassportVerifySTokenRequest? body,
+        [FromHeader(Name = "x-rpc-device_id")] string? deviceId,
+        [FromServices] SdkConfig sdkConfig,
+        [FromServices] IGeoIpLookup geoIp,
+        [FromServices] SdkDbContext db,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct
+    )
+    {
+        // A static type can't be a generic type argument (CS0718), so
+        // ILogger<T> isn't an option here. The factory caches by category,
+        // so this lookup is cheap.
+        var logger = loggerFactory.CreateLogger(typeof(PassportEndpoints).FullName!);
+
+        if (body is null || string.IsNullOrEmpty(body.Mid) || string.IsNullOrEmpty(body.SToken))
+            return Results.Ok(ApiResponse.From(Retcode.MaPassportParameterError));
+
+        if (string.IsNullOrEmpty(deviceId) || !SdkUtils.IsValidDeviceId(deviceId))
+            return Results.Ok(ApiResponse.From(Retcode.MaPassportParameterError));
+
+        var acc = await db.Accounts.FirstOrDefaultAsync(
+            a => a.SessionToken == body.SToken,
+            ct);
+
+        if (acc is null)
+            return Results.Ok(ApiResponse.From(Retcode.MaPassportAccountMismatch));
+
+        var login = sdkConfig.MaPassport.Login;
+
+        if (!login.SkipDeviceIdCheck
+            && acc.KnownDeviceIds.Count > 0
+            && !acc.KnownDeviceIds.Contains(deviceId))
+        {
+            return Results.Ok(ApiResponse.From(Retcode.MaPassportAccountNewDeviceDetected));
+        }
+
+        acc.RegisterDevice(deviceId);
+
+        var country = await geoIp.GetCountryCodeAsync(
+            SdkHttpHelpers.GetClientIp(httpContext),
+            ct).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(country))
+            country = acc.Country;
+
+        if (string.IsNullOrWhiteSpace(country))
+            country = sdkConfig.DefaultCountryCode;
+
+        acc.Country = country;
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation("Verified stoken for account id {Id}", acc.Id);
+
+        return Results.Ok(ApiResponse.Ok(BuildLoginData(
+            acc,
+            (MaPassportTokenType)login.AuthTicketTokenType,
+            acc.SessionToken,
+            string.Empty,
+            string.Empty,
+            country)));
     }
 
     /// <summary>
@@ -369,7 +442,7 @@ public static class PassportEndpoints
         },
         UserInfo = new MaPassportUserInfo {
             Aid = acc.Id.ToString(),
-            Mid = acc.Id.ToString(),
+            Mid = SdkDefaults.DefaultMid,
             AccountName = acc.Username,
             Email = SdkHttpHelpers.MaskString(acc.Email),
             IsEmailVerify = 0,

--- a/Source/Starlight.SDK/Http/Models/MaPassportModels.cs
+++ b/Source/Starlight.SDK/Http/Models/MaPassportModels.cs
@@ -3,6 +3,21 @@ using System.Text.Json.Serialization;
 namespace Starlight.SDK.Http.Models;
 
 /// <summary>
+/// Body of <c>POST /hk4e_global/account/ma-passport/token/verifySToken</c>.
+/// No encryption occurs in any of the fields. <c>mid</c> is an opaque
+/// passport metadata identifier; Starlight accepts it for wire compatibility
+/// but authenticates the account using <c>stoken</c>.
+/// </summary>
+public sealed class MaPassportVerifySTokenRequest
+{
+    [JsonPropertyName("stoken")]
+    public string? SToken { get; set; }
+
+    [JsonPropertyName("mid")]
+    public string? Mid { get; set; }
+}
+
+/// <summary>
 /// Body of <c>POST /hk4e_global/account/ma-passport/api/appLoginByPassword</c>.
 /// Both <c>account</c> and <c>password</c> are RSA-encrypted by the client
 /// (base64-encoded PKCS#1 v1.5 cipher) and must be decrypted with the


### PR DESCRIPTION
<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->

## Summary
Adds support for validating existing ma-passport stoken sessions through the official verifySToken endpoint.

## Related Issues
Closes #5

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Maps POST /hk4e_global/account/ma-passport/token/verifySToken.
- Returns the token with the shared ma-passport login response.
- Refreshes account country and device information after successful verification.

## Implementation Details
Accounts are resolved using the persisted session token. The `mid` field is accepted for protocol compatibility but is not treated as an account ID because official MIDs are opaque strings and Starlight does not persist them per account.
The endpoint does not rotate the session token. Keeping the existing token is necessary because the client reuses it during the subsequent combo-token exchange.
Existing device validation behavior and the `SkipDeviceIdCheck` development option are preserved.

## Testing
- [ ] Unit tests added/updated
- [x] Existing tests pass
- [x] Manually tested

Describe how this was tested.

## Performance Impact
- [x] No impact
- [ ] Minor impact
- [ ] Significant impact (explain below)

## Breaking Changes
- [x] No
- [ ] Yes (describe below)

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] CI passes
- [x] No unnecessary changes included
- [x] Documentation updated (if needed)

<!-- IMPORTANT: Do not forget to assign labels and reviewers once the PR is crated. -->